### PR TITLE
Prepare MPSBackendImpl for intra-tdvp checkpoint/autosave

### DIFF
--- a/emu_base/math/brents_root_finding.py
+++ b/emu_base/math/brents_root_finding.py
@@ -1,4 +1,97 @@
-from typing import Callable
+from typing import Callable, Optional
+
+
+class BrentsRootFinder:
+    def __init__(
+        self,
+        *,
+        start: float,
+        end: float,
+        f_start: float,
+        f_end: float,
+        epsilon: float = 1e-6,
+    ):
+        self.epsilon = epsilon
+
+        assert start <= end
+        self.a, self.b = start, end
+        self.fa = f_start
+        self.fb = f_end
+
+        assert self.fa * self.fb < 0, "Function root needs to be between a and b"
+
+        # b has to be the better guess
+        if abs(self.fa) < abs(self.fb):
+            self.a, self.b = self.b, self.a
+            self.fa, self.fb = self.fb, self.fa
+
+        self.c = self.a
+        self.d = self.c
+        self.fc = self.fa
+
+        self.bisection = True
+        self.current_guess = self.b
+        self.next_abscissa: Optional[float] = None
+
+    def get_next_abscissa(self) -> float:
+        if abs(self.fc - self.fa) < self.epsilon or abs(self.fc - self.fb) < self.epsilon:
+            # Secant method
+            dx = self.fb * (self.b - self.a) / (self.fa - self.fb)
+        else:
+            # Inverse quadratic interpolation
+            s = self.fb / self.fa
+            r = self.fb / self.fc
+            t = self.fa / self.fc
+            q = (t - 1) * (s - 1) * (r - 1)
+            p = s * (t * (r - t) * (self.c - self.b) + (r - 1) * (self.b - self.a))
+            dx = p / q
+
+        # Use bisection instead of interpolation
+        # if the interpolation is not within bounds.
+        delta = abs(2 * self.epsilon * self.b)
+        adx = abs(dx)
+        delta_bc = abs(self.b - self.c)
+        delta_cd = abs(self.c - self.d)
+        delta_ab = self.a - self.b
+        if (
+            (adx >= abs(3 * delta_ab / 4) or dx * delta_ab < 0)
+            or (self.bisection and adx >= delta_bc / 2)
+            or (not self.bisection and adx >= delta_cd / 2)
+            or (self.bisection and delta_bc < delta)
+            or (not self.bisection and delta_cd < delta)
+        ):
+            dx = (self.a - self.b) / 2
+            self.bisection = True
+        else:
+            self.bisection = False
+
+        self.next_abscissa = self.b + dx
+        self.d = self.c
+        self.c, self.fc = self.b, self.fb
+
+        return self.next_abscissa
+
+    def provide_ordinate(self, abscissa: float, ordinate: float) -> None:
+        # First argument is just a safety
+        assert (
+            self.next_abscissa is not None and abscissa == self.next_abscissa
+        ), "Something went wrong"
+
+        # Update interval
+        if self.fa * ordinate < 0:
+            self.b, self.fb = abscissa, ordinate
+        else:
+            self.a, self.fa = abscissa, ordinate
+
+        # b has to be the better guess
+        if abs(self.fa) < abs(self.fb):
+            self.a, self.b = self.b, self.a
+            self.fa, self.fb = self.fb, self.fa
+
+        self.current_guess = self.b
+
+    def is_converged(self, tolerance: float) -> bool:
+        return abs(self.b - self.a) < tolerance
 
 
 def find_root_brents(
@@ -6,79 +99,23 @@ def find_root_brents(
     *,
     start: float,
     end: float,
-    f_start: float | None = None,
-    f_end: float | None = None,
+    f_start: Optional[float] = None,
+    f_end: Optional[float] = None,
     tolerance: float = 1e-6,
     epsilon: float = 1e-6,
 ) -> float:
     """
     Approximates and returns the zero of a scalar function using Brent's method.
     """
-    assert start <= end
-    a, b = start, end
-    fa = f_start or f(start)
-    fb = f_end or f(end)
+    f_start = f_start if f_start is not None else f(start)
+    f_end = f_end if f_end is not None else f(end)
 
-    assert fa * fb < 0, "Function root needs to be between a and b"
+    root_finder = BrentsRootFinder(
+        start=start, end=end, f_start=f_start, f_end=f_end, epsilon=epsilon
+    )
 
-    # b has to be the better guess
-    if abs(fa) < abs(fb):
-        a, b = b, a
-        fa, fb = fb, fa
+    while not root_finder.is_converged(tolerance):
+        x = root_finder.get_next_abscissa()
+        root_finder.provide_ordinate(x, f(x))
 
-    c = a
-    d = c
-    fc = fa
-
-    bisection = True
-    while abs(b - a) > tolerance:
-        if abs(fc - fa) < epsilon or abs(fc - fb) < epsilon:
-            # Secant method
-            dx = fb * (b - a) / (fa - fb)
-        else:
-            # Inverse quadratic interpolation
-            s = fb / fa
-            r = fb / fc
-            t = fa / fc
-            q = (t - 1) * (s - 1) * (r - 1)
-            p = s * (t * (r - t) * (c - b) + (r - 1) * (b - a))
-            dx = p / q
-
-        # Use bisection instead of interpolation
-        # if the interpolation is not within bounds.
-        delta = abs(2 * epsilon * b)
-        adx = abs(dx)
-        delta_bc = abs(b - c)
-        delta_cd = abs(c - d)
-        delta_ab = a - b
-        if (
-            (adx >= abs(3 * delta_ab / 4) or dx * delta_ab < 0)
-            or (bisection and adx >= delta_bc / 2)
-            or (not bisection and adx >= delta_cd / 2)
-            or (bisection and delta_bc < delta)
-            or (not bisection and delta_cd < delta)
-        ):
-            dx = (a - b) / 2
-            bisection = True
-        else:
-            bisection = False
-
-        x = b + dx
-        fx = f(x)
-        d = c
-        c, fc = b, fb
-
-        # Update interval
-        if fa * fx < 0:
-            b, fb = x, fx
-            fb = fx
-        else:
-            a, fa = x, fx
-            fa = fx
-
-        # b has to be the better guess
-        if abs(fa) < abs(fb):
-            a, b = b, a
-            fa, fb = fb, fa
-
-    return b
+    return root_finder.current_guess

--- a/emu_mps/mps_backend.py
+++ b/emu_mps/mps_backend.py
@@ -1,4 +1,3 @@
-from time import time
 from pulser import Sequence
 
 from emu_base import Backend, BackendConfig, Results
@@ -27,19 +26,10 @@ class MPSBackend(Backend):
 
         self.validate_sequence(sequence)
 
-        results = Results()
-
         impl = create_impl(sequence, mps_config)
         impl.init()  # This is separate from the constructor for testing purposes.
 
-        for step in range(impl.timestep_count):
-            start = time()
+        while not impl.is_finished():
+            impl.progress()
 
-            impl.do_time_step(step)
-
-            impl.fill_results(results, step)
-
-            end = time()
-            impl.log_step_statistics(results, step=step, duration=end - start)
-
-        return results
+        return impl.results

--- a/emu_mps/mps_backend_impl.py
+++ b/emu_mps/mps_backend_impl.py
@@ -4,20 +4,35 @@ from resource import RUSAGE_SELF, getrusage
 from typing import Optional
 
 import torch
+import time
 from pulser import Sequence
 
-from emu_base import Results, State, find_root_brents, PulserData
+from emu_base import Results, State, PulserData
+from emu_base.math.brents_root_finding import BrentsRootFinder
 from emu_mps.hamiltonian import make_H, update_H
 from emu_mps.mpo import MPO
 from emu_mps.mps import MPS
 from emu_mps.mps_config import MPSConfig
 from emu_mps.noise import compute_noise_from_lindbladians, pick_well_prepared_qubits
-from emu_mps.tdvp import evolve_tdvp
+from emu_mps.tdvp import (
+    evolve_single,
+    evolve_pair,
+    EvolveConfig,
+    new_right_bath,
+    right_baths,
+)
 from emu_mps.utils import (
     extended_mpo_factors,
     extended_mps_factors,
     get_extended_site_index,
+    new_left_bath,
 )
+from enum import Enum, auto
+
+
+class SwipeDirection(Enum):
+    LEFT_TO_RIGHT = auto()
+    RIGHT_TO_LEFT = auto()
 
 
 class MPSBackendImpl:
@@ -27,20 +42,44 @@ class MPSBackendImpl:
     well_prepared_qubits_filter: Optional[list[bool]]
     hamiltonian: MPO
     state: MPS
+    right_baths: list[torch.Tensor]
+    tdvp_index: int
+    swipe_direction: SwipeDirection
+    timestep_index: int
+    target_time: float
+    results: Results
 
     def __init__(self, mps_config: MPSConfig, pulser_data: PulserData):
         self.config = mps_config
+        self.target_time = float(self.config.dt)
         self.qubit_count = pulser_data.qubit_count
+        assert self.qubit_count >= 2
         self.omega = pulser_data.omega
         self.delta = pulser_data.delta
         self.phi = pulser_data.phi
-        self.timestep_count = self.omega.shape[0]
+        self.timestep_count: int = self.omega.shape[0]
         self.has_lindblad_noise = pulser_data.has_lindblad_noise
+        self.lindblad_noise = torch.zeros(2, 2, dtype=torch.complex128)
         self.full_interaction_matrix = pulser_data.full_interaction_matrix
         self.masked_interaction_matrix = pulser_data.masked_interaction_matrix
         self.hamiltonian_type = pulser_data.hamiltonian_type
         self.slm_end_time = pulser_data.slm_end_time
         self.is_masked = self.slm_end_time > 0.0
+        self.left_baths: list[torch.Tensor]
+        self.time = time.time()
+        self.swipe_direction = SwipeDirection.LEFT_TO_RIGHT
+        self.tdvp_index = 0
+        self.timestep_index = 0
+        self.results = Results()
+
+        self.evolve_config = EvolveConfig(
+            exp_tolerance=self.config.precision * self.config.extra_krylov_tolerance,
+            norm_tolerance=self.config.precision * self.config.extra_krylov_tolerance,
+            max_krylov_dim=self.config.max_krylov_dim,
+            is_hermitian=not self.has_lindblad_noise,
+            max_error=self.config.precision,
+            max_rank=self.config.max_bond_dim,
+        )
 
     def init_dark_qubits(self) -> None:
         has_state_preparation_error: bool = (
@@ -57,6 +96,8 @@ class MPSBackendImpl:
         )
 
         if self.well_prepared_qubits_filter is not None:
+            self.qubit_count = sum(1 for x in self.well_prepared_qubits_filter if x)
+
             self.full_interaction_matrix = self.full_interaction_matrix[
                 self.well_prepared_qubits_filter, :
             ][:, self.well_prepared_qubits_filter]
@@ -67,16 +108,10 @@ class MPSBackendImpl:
             self.delta = self.delta[:, self.well_prepared_qubits_filter]
             self.phi = self.phi[:, self.well_prepared_qubits_filter]
 
-    def init_initial_state(self, initial_state: State | None) -> None:
+    def init_initial_state(self, initial_state: State | None = None) -> None:
         if initial_state is None:
-            well_prepared_qubits_count: int = (
-                self.qubit_count
-                if self.well_prepared_qubits_filter is None
-                else sum(1 for x in self.well_prepared_qubits_filter if x)
-            )
-
             self.state = MPS.make(
-                well_prepared_qubits_count,
+                self.qubit_count,
                 precision=self.config.precision,
                 max_bond_dim=self.config.max_bond_dim,
                 num_gpus_to_use=self.config.num_gpus_to_use,
@@ -107,42 +142,187 @@ class MPSBackendImpl:
         too many factors are put in the Hamiltonian
         """
         self.hamiltonian = make_H(
-            interaction_matrix=self.masked_interaction_matrix,
+            interaction_matrix=self.masked_interaction_matrix
+            if self.is_masked
+            else self.full_interaction_matrix,
             hamiltonian_type=self.hamiltonian_type,
             num_gpus_to_use=self.config.num_gpus_to_use,
         )
+
+        update_H(
+            hamiltonian=self.hamiltonian,
+            omega=self.omega[self.timestep_index, :],
+            delta=self.delta[self.timestep_index, :],
+            phi=self.phi[self.timestep_index, :],
+            noise=self.lindblad_noise,
+        )
+
+    def init_baths(self) -> None:
+        self.left_baths = [
+            torch.ones(
+                1, 1, 1, dtype=torch.complex128, device=self.state.factors[0].device
+            )
+        ]
+        self.right_baths = right_baths(self.state, self.hamiltonian, final_qubit=2)
+        assert len(self.right_baths) == self.qubit_count - 1
 
     def init(self) -> None:
         self.init_dark_qubits()
         self.init_initial_state(self.config.initial_state)
         self.init_hamiltonian()
+        self.init_baths()
 
-    def evolve_to_time(self, intermediate_time: float) -> float:
-        """
-        Internal method to evolve the state to `intermediate_time`
-        with the FIXED current self.hamiltonian.
-        """
-        _TIME_CONVERSION_COEFF = 0.001  # Omega and delta are given in rad/ms, dt in ns
-        delta_time = intermediate_time - self.current_time
-        evolve_tdvp(
-            t=-_TIME_CONVERSION_COEFF * delta_time * 1j,
-            state=self.state,
-            hamiltonian=self.hamiltonian,
-            extra_krylov_tolerance=self.config.extra_krylov_tolerance,
-            max_krylov_dim=self.config.max_krylov_dim,
-            is_hermitian=not self.has_lindblad_noise,
-        )
-        self.current_time = intermediate_time
-        return 0.0  # For typing
+    def is_finished(self) -> bool:
+        return self.timestep_index >= self.timestep_count
 
-    def do_time_step(self, step: int) -> None:
+    def _evolve(
+        self, *indices: int, dt: float, orth_center_right: Optional[bool] = None
+    ) -> None:
         """
-        Updates hamiltonian and evolves state by dt.
+        Time-evolve the state's tensors located at the given 1 or 2 indices by dt,
+        using the baths stored in self.left_baths and self.right_baths.
+        When 2 indices are given, they need to be consecutive.
+        Updates the state's orthogonality center according to orth_center_right.
         """
-        assert not self.has_lindblad_noise
+        assert 1 <= len(indices) <= 2
 
-        target_time = float((step + 1) * self.config.dt)
-        if self.is_masked and target_time > self.slm_end_time:
+        baths = (self.left_baths[-1], self.right_baths[-1])
+
+        if len(indices) == 1:
+            assert orth_center_right is None
+            (index,) = indices
+            assert self.state.orthogonality_center == index
+
+            self.state.factors[index] = evolve_single(
+                state_factor=self.state.factors[index],
+                ham_factor=self.hamiltonian.factors[index],
+                baths=baths,
+                dt=dt,
+                config=self.evolve_config,
+            )
+        else:
+            assert orth_center_right is not None
+            l, r = indices
+            assert r == l + 1, "Indices need to be consecutive"
+            assert self.state.orthogonality_center in {l, r}, (
+                "State needs to be orthogonalized" " on one of the evolved indices"
+            )
+
+            self.state.factors[l : r + 1] = evolve_pair(
+                state_factors=self.state.factors[l : r + 1],
+                ham_factors=self.hamiltonian.factors[l : r + 1],
+                baths=baths,
+                dt=dt,
+                config=self.evolve_config,
+                orth_center_right=orth_center_right,
+            )
+
+            self.state.orthogonality_center = r if orth_center_right else l
+
+    def progress(self) -> None:
+        """
+        Do one unit of simulation work given the current state.
+        Update the state accordingly.
+        The state of the simulation is stored in self.tdvp_index and self.swipe_direction.
+        """
+        if self.is_finished():
+            return
+
+        delta_time = self.target_time - self.current_time
+
+        assert self.qubit_count >= 1
+        if 1 <= self.qubit_count <= 2:
+            # Corner case: only 1 or 2 qubits
+            assert self.swipe_direction == SwipeDirection.LEFT_TO_RIGHT
+            assert self.tdvp_index == 0
+
+            if self.qubit_count == 1:
+                self._evolve(0, dt=delta_time)
+            else:
+                self._evolve(0, 1, dt=delta_time, orth_center_right=False)
+
+            self.tdvp_complete()
+
+        elif (
+            self.tdvp_index < self.qubit_count - 2
+            and self.swipe_direction == SwipeDirection.LEFT_TO_RIGHT
+        ):
+            # Left-to-right swipe of TDVP
+            self._evolve(
+                self.tdvp_index,
+                self.tdvp_index + 1,
+                dt=delta_time / 2,
+                orth_center_right=True,
+            )
+            self.left_baths.append(
+                new_left_bath(
+                    self.left_baths[-1],
+                    self.state.factors[self.tdvp_index],
+                    self.hamiltonian.factors[self.tdvp_index],
+                )
+            )
+            self._evolve(self.tdvp_index + 1, dt=-delta_time / 2)
+            self.right_baths.pop()
+            self.tdvp_index += 1
+
+        elif (
+            self.tdvp_index == self.qubit_count - 2
+            and self.swipe_direction == SwipeDirection.LEFT_TO_RIGHT
+        ):
+            # Time-evolution of the rightmost 2 tensors
+            self._evolve(
+                self.tdvp_index,
+                self.tdvp_index + 1,
+                dt=delta_time,
+                orth_center_right=False,
+            )
+            self.swipe_direction = SwipeDirection.RIGHT_TO_LEFT
+
+        elif (
+            1 <= self.tdvp_index and self.swipe_direction == SwipeDirection.RIGHT_TO_LEFT
+        ):
+            # Right-to-left swipe of TDVP
+            assert self.tdvp_index <= self.qubit_count - 2
+            self.right_baths.append(
+                new_right_bath(
+                    self.right_baths[-1],
+                    self.state.factors[self.tdvp_index + 1],
+                    self.hamiltonian.factors[self.tdvp_index + 1],
+                )
+            )
+            if not self.has_lindblad_noise:
+                # Free memory because it won't be used anymore
+                self.right_baths[-2] = None
+
+            self._evolve(self.tdvp_index, dt=-delta_time / 2)
+            self.left_baths.pop()
+
+            self._evolve(
+                self.tdvp_index - 1,
+                self.tdvp_index,
+                dt=delta_time / 2,
+                orth_center_right=False,
+            )
+            self.tdvp_index -= 1
+
+            if self.tdvp_index == 0:
+                self.tdvp_complete()
+                self.swipe_direction = SwipeDirection.LEFT_TO_RIGHT
+
+        else:
+            raise Exception("Didn't expect this")
+
+        # TODO: checkpoint/autosave here
+
+    def tdvp_complete(self) -> None:
+        self.current_time = self.target_time
+        self.timestep_complete()
+
+    def timestep_complete(self) -> None:
+        self.fill_results()
+        self.timestep_index += 1
+        self.target_time = float((self.timestep_index + 1) * self.config.dt)
+        if self.is_masked and self.current_time >= self.slm_end_time:
             self.is_masked = False
             self.hamiltonian = make_H(
                 interaction_matrix=self.full_interaction_matrix,
@@ -150,28 +330,36 @@ class MPSBackendImpl:
                 num_gpus_to_use=self.config.num_gpus_to_use,
             )
 
-        update_H(
-            hamiltonian=self.hamiltonian,
-            omega=self.omega[step, :],
-            delta=self.delta[step, :],
-            phi=self.phi[step, :],
-        )
+        if not self.is_finished():
+            update_H(
+                hamiltonian=self.hamiltonian,
+                omega=self.omega[self.timestep_index, :],
+                delta=self.delta[self.timestep_index, :],
+                phi=self.phi[self.timestep_index, :],
+                noise=self.lindblad_noise,
+            )
+            self.init_baths()
 
-        self.evolve_to_time(target_time)
+        self.log_step_statistics(duration=time.time() - self.time)
+        self.time = time.time()
 
-    def fill_results(self, results: Results, step: int) -> None:
-        t = (step + 1) * self.config.dt  # we are now after the time-step, so use step+1
-
+    def fill_results(self) -> None:
         normalized_state = 1 / self.state.norm() * self.state
 
         if self.well_prepared_qubits_filter is None:
             for callback in self.config.callbacks:
-                callback(self.config, t, normalized_state, self.hamiltonian, results)
+                callback(
+                    self.config,
+                    self.current_time,
+                    normalized_state,
+                    self.hamiltonian,
+                    self.results,
+                )
             return
 
         full_mpo, full_state = None, None
         for callback in self.config.callbacks:
-            if t not in callback.evaluation_times:
+            if self.current_time not in callback.evaluation_times:
                 continue
 
             if full_mpo is None or full_state is None:
@@ -192,11 +380,9 @@ class MPSBackendImpl:
                     ),
                 )
 
-            callback(self.config, t, full_state, full_mpo, results)
+            callback(self.config, self.current_time, full_state, full_mpo, self.results)
 
-    def log_step_statistics(
-        self, results: Results, *, step: int, duration: float
-    ) -> None:
+    def log_step_statistics(self, *, duration: float) -> None:
         if self.state.factors[0].is_cuda:
             max_mem_per_device = (
                 torch.cuda.max_memory_allocated(device) * 1e-6
@@ -207,21 +393,21 @@ class MPSBackendImpl:
             max_mem = getrusage(RUSAGE_SELF).ru_maxrss * 1e-3
 
         self.config.logger.info(
-            f"step = {step + 1}/{self.timestep_count}, "
+            f"step = {self.timestep_index}/{self.timestep_count}, "
             + f"χ = {self.state.get_max_bond_dim()}, "
             + f"|ψ| = {self.state.get_memory_footprint():.3f} MB, "
             + f"RSS = {max_mem:.3f} MB, "
             + f"Δt = {duration:.3f} s"
         )
 
-        if results.statistics is None:
-            assert step == 0
-            results.statistics = {"steps": []}
+        if self.results.statistics is None:
+            assert self.timestep_index == 1
+            self.results.statistics = {"steps": []}
 
-        assert "steps" in results.statistics
-        assert len(results.statistics["steps"]) == step
+        assert "steps" in self.results.statistics
+        assert len(self.results.statistics["steps"]) == self.timestep_index - 1
 
-        results.statistics["steps"].append(
+        self.results.statistics["steps"].append(
             {
                 "max_bond_dimension": self.state.get_max_bond_dim(),
                 "memory_footprint": self.state.get_memory_footprint(),
@@ -233,22 +419,24 @@ class MPSBackendImpl:
 
 class NoisyMPSBackendImpl(MPSBackendImpl):
     """
-    Version of MPSBackendImpl with lindbladian noise.
+    Version of MPSBackendImpl with non-zero lindbladian noise.
     Implements the Monte-Carlo Wave Function jump method.
     """
 
-    lindblad_noise: torch.Tensor
     jump_threshold: float
-    aggregated_lindblad_ops: Optional[torch.Tensor] = None
+    aggregated_lindblad_ops: Optional[torch.Tensor]
     norm_gap_before_jump: float
+    root_finder: Optional[BrentsRootFinder]
 
     def __init__(self, config: MPSConfig, pulser_data: PulserData):
         super().__init__(config, pulser_data)
+        self.aggregated_lindblad_ops = None
         self.lindblad_ops = pulser_data.lindblad_ops
+        self.root_finder = None
 
-    def init_lindblad_noise(self) -> None:
         assert self.has_lindblad_noise
 
+    def init_lindblad_noise(self) -> None:
         stacked = torch.stack(self.lindblad_ops)
         # The below is used for batch computation of noise collapse weights.
         self.aggregated_lindblad_ops = stacked.conj().transpose(1, 2) @ stacked
@@ -261,62 +449,42 @@ class NoisyMPSBackendImpl(MPSBackendImpl):
         super().init()
         self.init_lindblad_noise()
 
-    def evolve_to_time(self, intermediate_time: float) -> float:
-        """
-        Sets and returns the relative distance to the quantum jump threshold.
-        """
-        super().evolve_to_time(intermediate_time)
+    def tdvp_complete(self) -> None:
+        previous_time = self.current_time
+        self.current_time = self.target_time
+        previous_norm_gap_before_jump = self.norm_gap_before_jump
         self.norm_gap_before_jump = self.state.norm() ** 2 - self.jump_threshold
-        return self.norm_gap_before_jump
 
-    def do_time_step(self, step: int) -> None:
-        """
-        Updates hamiltonian and evolves state by dt.
-        """
-        target_time = float((step + 1) * self.config.dt)
-        if self.is_masked and target_time > self.slm_end_time:
-            self.is_masked = False
-            self.hamiltonian = make_H(
-                interaction_matrix=self.full_interaction_matrix,
-                hamiltonian_type=self.hamiltonian_type,
-                num_gpus_to_use=self.config.num_gpus_to_use,
-            )
-
-        update_H(
-            hamiltonian=self.hamiltonian,
-            omega=self.omega[step, :],
-            delta=self.delta[step, :],
-            phi=self.phi[step, :],
-            noise=self.lindblad_noise,
-        )
-
-        while self.current_time != target_time:
-            assert self.current_time < target_time
-
-            time_at_begin = self.current_time
-            norm_gap_at_begin = self.norm_gap_before_jump
-            assert norm_gap_at_begin >= 0.0
-
-            norm_gap_at_target_time = self.evolve_to_time(target_time)
-
-            should_jump: bool = norm_gap_at_target_time < 0
-            if should_jump:
-                # Evolve to the intermediate time between self.current_time and target_time
-                # where the jump should occur. That corresponds to self.evolve_to_time(t_jump) == 0.
-                find_root_brents(
-                    f=self.evolve_to_time,
-                    start=time_at_begin,
-                    f_start=norm_gap_at_begin,
-                    end=target_time,
-                    f_end=norm_gap_at_target_time,
-                    tolerance=1.0,
+        if self.root_finder is None:
+            # No quantum jump location finding in progress
+            if self.norm_gap_before_jump < 0:
+                # Initiate quantum jump location finding
+                # Jump occurs when norm_gap_before_jump ~ 0
+                self.root_finder = BrentsRootFinder(
+                    start=previous_time,
+                    end=self.current_time,
+                    f_start=previous_norm_gap_before_jump,
+                    f_end=self.norm_gap_before_jump,
+                    epsilon=1,
                 )
-                self.do_random_quantum_jump()
-        assert self.current_time == target_time
+                self.target_time = self.root_finder.get_next_abscissa()
+            else:
+                self.timestep_complete()
+
+            return
+
+        self.norm_gap_before_jump = self.state.norm() ** 2 - self.jump_threshold
+        self.root_finder.provide_ordinate(self.current_time, self.norm_gap_before_jump)
+
+        if self.root_finder.is_converged(tolerance=1):
+            self.do_random_quantum_jump()
+            self.target_time = (self.timestep_index + 1) * self.config.dt
+            self.root_finder = None
+        else:
+            self.target_time = self.root_finder.get_next_abscissa()
 
     def do_random_quantum_jump(self) -> None:
         jump_operator_weights = self.state.expect_batch(self.aggregated_lindblad_ops).real
-
         jumped_qubit_index, jump_operator = random.choices(
             [
                 (qubit, op)
@@ -327,6 +495,7 @@ class NoisyMPSBackendImpl(MPSBackendImpl):
         )[0]
 
         self.state.apply(jumped_qubit_index, jump_operator)
+        self.state.orthogonalize(0)
         self.state *= 1 / self.state.norm()
 
         norm_after_normalizing = self.state.norm()
@@ -334,17 +503,17 @@ class NoisyMPSBackendImpl(MPSBackendImpl):
         self.jump_threshold = random.uniform(0.0, norm_after_normalizing**2)
         self.norm_gap_before_jump = norm_after_normalizing**2 - self.jump_threshold
 
-    def fill_results(self, results: Results, step: int) -> None:
+    def fill_results(self) -> None:
         # Remove the noise from self.hamiltonian for the callbacks.
         # Since update_H is called at the start of do_time_step this is safe.
         update_H(
             hamiltonian=self.hamiltonian,
-            omega=self.omega[step, :],
-            delta=self.delta[step, :],
-            phi=self.phi[step, :],
+            omega=self.omega[self.timestep_index - 1, :],  # Meh
+            delta=self.delta[self.timestep_index - 1, :],
+            phi=self.phi[self.timestep_index - 1, :],
         )
 
-        super().fill_results(results, step)
+        super().fill_results()
 
 
 def create_impl(sequence: Sequence, config: MPSConfig) -> MPSBackendImpl:

--- a/test/emu_mps/test_mps_backend_impl.py
+++ b/test/emu_mps/test_mps_backend_impl.py
@@ -2,7 +2,7 @@ from emu_mps.mps_backend_impl import MPSBackendImpl, NoisyMPSBackendImpl
 from emu_mps.mps_config import MPSConfig
 import math
 import cmath
-from unittest.mock import MagicMock, patch, ANY, call
+from unittest.mock import MagicMock, patch
 from emu_mps.mps import MPS
 import torch
 import pytest
@@ -218,14 +218,21 @@ def test_init_lindblad_noise_with_lindbladians(
     assert math.isclose(victim.norm_gap_before_jump, 0.877)
 
 
-def test_init_initial_state_default():
-    victim = create_victim()
+@patch("emu_mps.mps_backend_impl.pick_well_prepared_qubits")
+def test_init_initial_state_default(pick_well_prepared_qubits_mock):
+    pick_well_prepared_qubits_mock.return_value = [True, False, False, True, True]
 
-    victim.well_prepared_qubits_filter = [True, False, False, True, True]
+    noise_model = MagicMock()
+    noise_model.state_prep_error = 0.1
+
+    victim = create_victim(noise_model=noise_model)
+
     victim.config.precision = 0.001
     victim.config.max_bond_dim = 100
     victim.config.num_gpus_to_use = 0
-    victim.init_initial_state(None)
+    victim.init_dark_qubits()
+    pick_well_prepared_qubits_mock.assert_called_once_with(0.1, QUBIT_COUNT)
+    victim.init_initial_state()
 
     expected = MPS.make(3, num_gpus_to_use=0)
 
@@ -259,174 +266,14 @@ def test_init_initial_state_provided_normalized():
 
     up = torch.tensor([[[0], [1]]], dtype=torch.complex128)
     down = torch.tensor([[[1], [0]]], dtype=torch.complex128)
-    victim.init_initial_state(MPS([up, up, down, up, down]))
+    victim.init_initial_state(0.123 * MPS([up, up, down, up, down]))
     assert cmath.isclose(victim.state.inner(MPS([up, up, down, up, down])), 1)
 
 
 @patch("emu_mps.mps_backend_impl.make_H")
-def test_init_hamiltonian(make_H_mock):
+@patch("emu_mps.mps_backend_impl.update_H")
+def test_init_hamiltonian(update_H_mock, make_H_mock):
     victim = create_victim()
     victim.init_hamiltonian()
     assert make_H_mock.call_count == 1
-
-
-@patch("emu_mps.mps_backend_impl.evolve_tdvp")
-@patch("emu_mps.mps_backend_impl.make_H")
-@patch("emu_mps.mps_backend_impl.update_H")
-def test_do_time_step_without_noise(update_H_mock, make_H_mock, evolve_tdvp_mock):
-    victim = create_victim()
-
-    victim.state = MPS.make(5)
-    victim.init_hamiltonian()
-
-    def evolve_tdvp_mock_side_effect(
-        t, state, hamiltonian, extra_krylov_tolerance, max_krylov_dim, is_hermitian
-    ):
-        assert state.orthogonality_center is not None
-        # Drastic norm decrease.
-        state.factors[state.orthogonality_center] = (
-            0.6 * state.factors[state.orthogonality_center]
-        )
-
-    evolve_tdvp_mock.side_effect = evolve_tdvp_mock_side_effect
-    victim.do_time_step(0)  # No quantum jump attempted in the absence of noise.
-
-    assert evolve_tdvp_mock.call_count == 1
-    assert victim.is_masked is True
-    assert math.isclose(victim.state.norm(), 0.6)
     assert update_H_mock.call_count == 1
-    assert make_H_mock.call_count == 1
-
-    victim.do_time_step(1)  # No quantum jump attempted in the absence of noise.
-    assert update_H_mock.call_count == 2
-    assert make_H_mock.call_count == 2
-    assert victim.is_masked is False
-
-
-@patch("emu_mps.mps_backend_impl.evolve_tdvp")
-@patch("emu_mps.mps_backend_impl.make_H")
-@patch("emu_mps.mps_backend_impl.update_H")
-@patch("emu_mps.mps_backend_impl.find_root_brents")
-@patch("emu_base.pulser_adapter._get_all_lindblad_noise_operators")
-@patch("emu_mps.mps_backend_impl.NoisyMPSBackendImpl.do_random_quantum_jump")
-def test_do_time_step_with_noise(
-    do_random_quantum_jump_mock,
-    get_all_lindblad_noise_operators_mock,
-    find_root_brents_mock,
-    update_H_mock,
-    make_H_mock,
-    evolve_tdvp_mock,
-):
-    victim = create_noisy_victim(dt=12)
-    victim.init_hamiltonian()
-
-    test_jump_threshold = 0.8
-    victim.jump_threshold = test_jump_threshold
-    victim.norm_gap_before_jump = 0.2
-    victim.has_lindblad_noise = False
-    victim.lindblad_noise = torch.ones(2, 2, dtype=torch.complex128)
-    victim.slm_end_time = 100
-    victim.state = MPS.make(5)
-    victim.has_lindblad_noise = True
-
-    # Test data for how much the state's norm decreases over time.
-    norms_per_time = {
-        0: 1,
-        3: 0.9,
-        6: test_jump_threshold,  # t=6 is where the collapse should happen.
-        11: 0.7,
-        12: 0.6,  # dt, i.e. the target time of do_time_step
-    }
-
-    def find_root_brents_mock_side_effect(f, start, end, f_start, f_end, tolerance):
-        assert start == 0
-        assert end == 12
-        assert math.isclose(f_start, 1**2 - test_jump_threshold)
-        assert math.isclose(f_end, norms_per_time[end] ** 2 - test_jump_threshold)
-
-        # Root finding iterations
-        f(3)
-        f(11)
-        f(6)
-        return 6  # norms_per_time[6] is the given collapse_threshold.
-
-    find_root_brents_mock.side_effect = find_root_brents_mock_side_effect
-
-    def evolve_tdvp_mock_side_effect(
-        t, state, hamiltonian, extra_krylov_tolerance, max_krylov_dim, is_hermitian
-    ):
-        delta_t = t
-        assert state.orthogonality_center is not None
-        assert delta_t.real == 0
-        target_t = victim.current_time - delta_t.imag * 1000
-        assert 3 - _ATOL <= target_t <= 12 + _ATOL
-        assert round(target_t) in norms_per_time
-        assert math.isclose(state.norm(), norms_per_time[int(victim.current_time)])
-        state.factors[state.orthogonality_center] = (
-            norms_per_time[round(target_t)]
-            * MPS.make(QUBIT_COUNT).factors[state.orthogonality_center]
-        )
-
-    evolve_tdvp_mock.side_effect = evolve_tdvp_mock_side_effect
-
-    def do_random_quantum_jump_side_effect():
-        victim.jump_threshold = 0.2  # Reset after jump at t=6.
-        victim.norm_gap_before_jump = 0.8
-        # The state should also be normalized here but we don't need it for this test.
-
-    do_random_quantum_jump_mock.side_effect = do_random_quantum_jump_side_effect
-    victim.do_time_step(0)
-    do_random_quantum_jump_mock.assert_called_once()
-    find_root_brents_mock.assert_called_once()
-    evolve_tdvp_mock.assert_has_calls(
-        [
-            # Initial call: t=0 -> t=12
-            call(
-                t=pytest.approx(-0.012j, abs=_ATOL),
-                state=ANY,
-                hamiltonian=ANY,
-                extra_krylov_tolerance=ANY,
-                max_krylov_dim=ANY,
-                is_hermitian=False,
-            ),
-            # Root finding call: t=12 -> t=3
-            call(
-                t=pytest.approx(0.009j, abs=_ATOL),
-                state=ANY,
-                hamiltonian=ANY,
-                extra_krylov_tolerance=ANY,
-                max_krylov_dim=ANY,
-                is_hermitian=False,
-            ),
-            # Root finding call: t=3 -> t=11
-            call(
-                t=pytest.approx(-0.008j, abs=_ATOL),
-                state=ANY,
-                hamiltonian=ANY,
-                extra_krylov_tolerance=ANY,
-                max_krylov_dim=ANY,
-                is_hermitian=False,
-            ),
-            # Root finding call: t=11 -> t=6
-            call(
-                t=pytest.approx(0.005j, abs=_ATOL),
-                state=ANY,
-                hamiltonian=ANY,
-                extra_krylov_tolerance=ANY,
-                max_krylov_dim=ANY,
-                is_hermitian=False,
-            ),
-            # Post jump: t=6 -> t=dt == 12
-            call(
-                t=pytest.approx(-0.006j, abs=_ATOL),
-                state=ANY,
-                hamiltonian=ANY,
-                extra_krylov_tolerance=ANY,
-                max_krylov_dim=ANY,
-                is_hermitian=False,
-            ),
-        ]
-    )
-    assert evolve_tdvp_mock.call_count == 5
-    assert update_H_mock.call_count == 1
-    assert make_H_mock.call_count == 1

--- a/test/emu_mps/test_tdvp.py
+++ b/test/emu_mps/test_tdvp.py
@@ -1,75 +1,13 @@
-from unittest.mock import MagicMock, patch
-
 import torch
-
-from emu_mps import MPO, MPS, inner
-from emu_mps.hamiltonian import make_H, update_H
-from emu_base.pulser_adapter import _rydberg_interaction, HamiltonianType
 from emu_base.math import krylov_exp
-from emu_mps.tdvp import apply_effective_Hamiltonian, evolve_tdvp, left_baths, right_baths
-
-
-def test_left_baths_bell():
-    # state = (|0> + |1>)^3 / norm
-    mps_factor1 = torch.tensor([[[1, 0], [0, 1]]], dtype=torch.complex128)
-    mps_factor2 = torch.tensor(
-        [[[1, 0], [0, 0]], [[0, 0], [0, 1]]], dtype=torch.complex128
-    )
-    mps_factor3 = torch.tensor([[[1], [0]], [[0], [1]]], dtype=torch.complex128)
-
-    # Hamiltonian X1*X2*X3
-    mpo_factor = torch.tensor([[[[0], [1]], [[1], [0]]]], dtype=torch.complex128)
-
-    state = MPS([mps_factor1, mps_factor2, mps_factor3])
-    obs = MPO([mpo_factor] * 3)
-    for i, b in enumerate(left_baths(state, obs, 1)):
-        # Because the Hamiltonian flips all the spins, the baths have shape
-        # (2,1,2) and they're all pauli_x
-        if i == 0:
-            assert torch.allclose(
-                b, torch.ones(1, 1, 1, dtype=torch.complex128, device=b.device)
-            )
-        else:
-            assert torch.allclose(
-                b,
-                torch.tensor(
-                    [[[0, 1]], [[1, 0]]], dtype=torch.complex128, device=b.device
-                ),
-            )
-
-
-def test_left_baths_total_magnetization():
-    # Hamiltonian Z1+Z2+Z3
-    mpo_factor1 = torch.tensor(
-        [[[[1, 1], [0, 0]], [[0, 0], [-1, 1]]]], dtype=torch.complex128
-    )
-    mpo_factor2 = torch.tensor(
-        [[[[1, 0], [0, 0]], [[0, 0], [1, 0]]], [[[1, 1], [0, 0]], [[0, 0], [-1, 1]]]],
-        dtype=torch.complex128,
-    )
-    mpo_factor3 = torch.tensor(
-        [[[[1], [0]], [[0], [1]]], [[[1], [0]], [[0], [-1]]]], dtype=torch.complex128
-    )
-
-    # state |111>
-    mps_factor = torch.tensor([[[0], [1]]], dtype=torch.complex128)
-
-    state = MPS([mps_factor] * 3)
-    obs = MPO([mpo_factor1, mpo_factor2, mpo_factor3])
-    baths = left_baths(state, obs, 1)
-    # The baths carry the information of the magnetization, so the baths have shape
-    # (1,2,1), and L_i = [-i,1], which basically counts how magnetized the bath is.
-    assert torch.allclose(
-        baths[0], torch.ones(1, 1, 1, dtype=torch.complex128, device=baths[0].device)
-    )
-    assert torch.allclose(
-        baths[1],
-        torch.tensor([[[-1], [1]]], dtype=torch.complex128, device=baths[1].device),
-    )
-    assert torch.allclose(
-        baths[2],
-        torch.tensor([[[-2], [1]]], dtype=torch.complex128, device=baths[2].device),
-    )
+from emu_mps import MPS, MPO
+from emu_mps.tdvp import (
+    apply_effective_Hamiltonian,
+    right_baths,
+    evolve_single,
+    EvolveConfig,
+    evolve_pair,
+)
 
 
 def test_right_baths_bell():
@@ -136,14 +74,14 @@ def test_right_baths_total_magnetization():
 
 
 def test_apply_2_site_effective_Hamiltonian():
-    left_bath = torch.randn(2, 3, 4, dtype=torch.complex128)
-    right_bath = torch.randn(5, 6, 7, dtype=torch.complex128)
+    left_bath = torch.randn(4, 3, 4, dtype=torch.complex128)
+    right_bath = torch.randn(7, 6, 7, dtype=torch.complex128)
     state = torch.randn(4, 4, 7, dtype=torch.complex128)
     left_ham = torch.randn(3, 2, 2, 8, dtype=torch.complex128)
     right_ham = torch.randn(8, 2, 2, 6, dtype=torch.complex128)
     ham = torch.einsum("ijkl,lmno->ijmkno", left_ham, right_ham).reshape(3, 4, 4, 6)
     actual = apply_effective_Hamiltonian(state, ham, left_bath, right_bath)
-    assert actual.shape == (2, 4, 5)
+    assert actual.shape == (4, 4, 7)
     # this is the expression apply_2_site_Hamiltonian implements,
     # but doing it manually is much faster
     expected = torch.einsum(
@@ -153,17 +91,17 @@ def test_apply_2_site_effective_Hamiltonian():
         right_ham,
         left_bath,
         right_bath,
-    ).reshape(2, 4, 5)
+    ).reshape(4, 4, 7)
     assert torch.allclose(actual, expected)
 
 
 def test_apply_1_site_effective_Hamiltonian():
-    left_bath = torch.randn(2, 3, 4, dtype=torch.complex128)
-    right_bath = torch.randn(5, 6, 7, dtype=torch.complex128)
+    left_bath = torch.randn(4, 3, 4, dtype=torch.complex128)
+    right_bath = torch.randn(7, 6, 7, dtype=torch.complex128)
     state = torch.randn(4, 2, 7, dtype=torch.complex128)
     ham = torch.randn(3, 2, 2, 6, dtype=torch.complex128)
     actual = apply_effective_Hamiltonian(state, ham, left_bath, right_bath)
-    assert actual.shape == (2, 2, 5)
+    assert actual.shape == (4, 2, 7)
     # this is the expression apply_2_site_Hamiltonian implements,
     # but doing it manually is much faster
     expected = torch.einsum(
@@ -172,7 +110,7 @@ def test_apply_1_site_effective_Hamiltonian():
         ham,
         left_bath,
         right_bath,
-    ).reshape(2, 2, 5)
+    ).reshape(4, 2, 7)
     assert torch.allclose(actual, expected)
 
 
@@ -252,100 +190,82 @@ def test_krylov_exp_krylov_exp_tolerance():
     assert torch.allclose(result[:, 0, 0], expected)
 
 
-def test_evolve_tdvp():
-    # X1+X2+X3
-    mpo_factor1 = torch.tensor(
-        [[[[0, 1], [1, 0]], [[1, 0], [0, 1]]]], dtype=torch.complex128
-    )
-    mpo_factor2 = torch.tensor(
-        [[[[1, 0], [0, 0]], [[0, 0], [1, 0]]], [[[0, 1], [1, 0]], [[1, 0], [0, 1]]]],
-        dtype=torch.complex128,
-    )
-    mpo_factor3 = torch.tensor(
-        [[[[1], [0]], [[0], [1]]], [[[0], [1]], [[1], [0]]]], dtype=torch.complex128
+def test_evolve_single():
+    left_bath = torch.rand(3, 4, 3, dtype=torch.complex128)
+    right_bath = torch.rand(4, 5, 4, dtype=torch.complex128)
+    state_factor = torch.rand(3, 2, 4, dtype=torch.complex128)
+    ham_factor = torch.rand(4, 2, 2, 5, dtype=torch.complex128)
+
+    op = torch.einsum("abc,bdef,gfh->cehadg", left_bath, ham_factor, right_bath).reshape(
+        3 * 2 * 4, -1
     )
 
-    # state |11111>
-    mps_factor = torch.tensor([[[0], [1]]], dtype=torch.complex128)
+    dt = 0.0001
 
-    state = MPS([mps_factor] * 5)
-    obs = MPO([mpo_factor1, mpo_factor2, mpo_factor2, mpo_factor2, mpo_factor3])
+    exp_op = torch.linalg.matrix_exp(-1j * 0.001 * dt * op)
 
-    # this applies tdvp in place
-    evolve_tdvp(-0.5j * torch.pi, state, obs, state.precision)
-    assert abs(inner(state, state) - 1) < 1e-8
+    expected = torch.tensordot(exp_op, state_factor.reshape(-1), dims=1).reshape(3, 2, 4)
 
-    # state -i|00000>
-    expected_factor = torch.tensor([[[-1.0j], [0]]], dtype=torch.complex128)
-    expected = MPS([expected_factor] * 5)
-
-    for factor in state.factors:
-        assert factor.shape == (1, 2, 1)
-    assert abs(inner(state, expected) - 1) < 1e-8
-
-
-@patch("emu_base.pulser_adapter.pulser.sequence.Sequence")
-def test_tdvp_state_vector(mock_sequence):
-    nqubits = 9
-    num_gpus = 0
-    c6 = 5420158.53  # mock device c6
-
-    qubit_positions = []
-    for i in range(3):
-        for j in range(3):
-            qubit_positions.append([7.0 * i, 7.0 * j])
-    qubit_positions = torch.tensor(qubit_positions)
-
-    omegas = torch.tensor([12.566370614359172] * nqubits, dtype=torch.complex128)
-    deltas = torch.tensor([10.771174812307862] * nqubits, dtype=torch.complex128)
-    phi = torch.tensor([1.570796327] * nqubits, dtype=torch.complex128)
-    mock_device = MagicMock(interaction_coeff=c6)
-    mock_sequence.device = mock_device
-
-    mock_register = MagicMock()
-    qubits_ids = [f"q{i}" for i in range(9)]
-    mock_register.qubit_ids = qubits_ids
-
-    abstract_q = []
-    for qubit in qubit_positions:
-        mock_abstract = MagicMock()
-        mock_abstract.as_tensor.return_value = qubit
-        abstract_q.append(mock_abstract)
-    mock_register.qubits = dict(zip(qubits_ids, abstract_q))
-    mock_sequence.register = mock_register
-    interaction_matrix = _rydberg_interaction(mock_sequence)
-
-    ham = make_H(
-        interaction_matrix=interaction_matrix,
-        hamiltonian_type=HamiltonianType.Rydberg,
-        num_gpus_to_use=num_gpus,
-    )
-    update_H(
-        hamiltonian=ham,
-        omega=omegas,
-        delta=deltas,
-        phi=phi,
+    actual = evolve_single(
+        state_factor=state_factor,
+        baths=(left_bath, right_bath),
+        ham_factor=ham_factor,
+        dt=dt,
+        config=EvolveConfig(
+            exp_tolerance=1e-10,
+            norm_tolerance=1e-10,
+            max_krylov_dim=1000,
+            is_hermitian=False,
+            max_error=1e-10,
+            max_rank=100,  # FIXME: max_error and max_rank are irrelevant for evolve_single
+        ),
     )
 
-    # |000000000>
-    state = MPS(
-        [torch.tensor([1.0, 0.0]).reshape(1, 2, 1).to(dtype=torch.complex128)] * nqubits,
-        precision=1e-10,
-        # run this on cpu, collecting the state vector from
-        # multiple devices is beside the point of the test
-        num_gpus_to_use=num_gpus,
+    assert torch.allclose(expected, actual, atol=1e-4)
+
+
+def test_evolve_pair():
+    left_bath = torch.rand(3, 4, 3, dtype=torch.complex128)
+    right_bath = torch.rand(5, 6, 5, dtype=torch.complex128)
+    left_state_factor = torch.rand(3, 2, 4, dtype=torch.complex128)
+    right_state_factor = torch.rand(4, 2, 5, dtype=torch.complex128)
+    left_ham_factor = torch.rand(4, 2, 2, 5, dtype=torch.complex128)
+    right_ham_factor = torch.rand(5, 2, 2, 6, dtype=torch.complex128)
+
+    op = torch.einsum(
+        "abc,bdef,fghi,jik->cehkadgj",
+        left_bath,
+        left_ham_factor,
+        right_ham_factor,
+        right_bath,
+    ).reshape(3 * 2 * 2 * 5, -1)
+
+    dt = 0.0001
+
+    exp_op = torch.linalg.matrix_exp(-1j * 0.001 * dt * op)
+
+    expected = torch.tensordot(
+        exp_op,
+        torch.tensordot(left_state_factor, right_state_factor, dims=1).reshape(-1),
+        dims=1,
+    ).reshape(3, 2, 2, 5)
+
+    actual_left, actual_right = evolve_pair(
+        state_factors=(left_state_factor, right_state_factor),
+        baths=(left_bath, right_bath),
+        ham_factors=(left_ham_factor, right_ham_factor),
+        dt=dt,
+        config=EvolveConfig(
+            exp_tolerance=1e-10,
+            norm_tolerance=1e-10,
+            max_krylov_dim=1000,
+            is_hermitian=False,
+            max_error=1e-10,
+            max_rank=1000,  # FIXME: max_error and max_rank are irrelevant for evolve_single
+        ),
+        orth_center_right=False,
     )
 
-    vec = torch.einsum(
-        "abtc,cdue,efvg,ghwi,ijxk,klym,mnzo,opAq,qrBs->abdfhjlnprtuvwxyzABs",
-        *(ham.factors),
-    ).reshape(2**nqubits, 2**nqubits)
-    expected = torch.linalg.matrix_exp(-0.01j * vec)[:, 0]
-    for _ in range(10):
-        evolve_tdvp(-0.001j, state, ham, state.precision)
-    vec = torch.einsum(
-        "abc,cde,efg,ghi,ijk,klm,mno,opq,qrs->abdfhjlnprs", *(state.factors)
-    ).reshape(2**nqubits)
-    assert abs(torch.dot(vec.conj(), expected) - 1) < 1e-10  # very dependent on precision
-    assert abs(torch.dot(vec.conj(), vec) - 1) < 1e-8
-    assert abs(torch.dot(expected.conj(), expected) - 1) < 1e-8
+    actual = torch.tensordot(actual_left, actual_right, dims=1)
+
+    assert torch.allclose(expected, actual, atol=1e-3)


### PR DESCRIPTION
Prepare the code for autosave, which needs to be able to save the state of the simulation for later resuming, even inside tdvp.

For this, the different steps of the tdvp logic are brought inside mps_backend_impl.
Baths are stored inside this same class.
Right baths from a right-left swipe are reused in the following left-right swipe, provided the hamiltonian doesn't change, which occurs in the absence of lindbladian noise.