### PR TITLE
Allow resuming simulation by regularly saving to file

### DIFF
--- a/emu_base/base_classes/config.py
+++ b/emu_base/base_classes/config.py
@@ -58,18 +58,11 @@ class BackendConfig:
         self.interaction_matrix = interaction_matrix
         self.interaction_cutoff = interaction_cutoff
         self.logger = logging.getLogger("global_logger")
-        if log_file is None:
-            logging.basicConfig(
-                level=log_level, format="%(message)s", stream=sys.stdout, force=True
-            )  # default to stream = sys.stderr
-        else:
-            logging.basicConfig(
-                level=log_level,
-                format="%(message)s",
-                filename=str(log_file),
-                filemode="w",
-                force=True,
-            )
+        self.log_file = log_file
+        self.log_level = log_level
+
+        self.init_logging()
+
         if noise_model is not None and (
             noise_model.runs != 1
             or noise_model.samples_per_run != 1
@@ -78,4 +71,18 @@ class BackendConfig:
         ):
             self.logger.warning(
                 "Warning: The runs and samples_per_run values of the NoiseModel are ignored!"
+            )
+
+    def init_logging(self) -> None:
+        if self.log_file is None:
+            logging.basicConfig(
+                level=self.log_level, format="%(message)s", stream=sys.stdout, force=True
+            )  # default to stream = sys.stderr
+        else:
+            logging.basicConfig(
+                level=self.log_level,
+                format="%(message)s",
+                filename=str(self.log_file),
+                filemode="w",
+                force=True,
             )

--- a/emu_mps/__init__.py
+++ b/emu_mps/__init__.py
@@ -10,10 +10,10 @@ from emu_base import (
     StateResult,
     SecondMomentOfEnergy,
 )
+from .mps_config import MPSConfig
 from .mpo import MPO
 from .mps import MPS, inner
 from .mps_backend import MPSBackend
-from .mps_config import MPSConfig
 
 
 __all__ = [

--- a/emu_mps/algebra.py
+++ b/emu_mps/algebra.py
@@ -1,7 +1,11 @@
 from __future__ import annotations
 
+from typing import Optional
+
 import torch
 import math
+
+from emu_mps import MPSConfig
 from emu_mps.utils import truncate_impl
 
 
@@ -115,8 +119,7 @@ def zip_right_step(
 def zip_right(
     top_factors: list[torch.tensor],
     bottom_factors: list[torch.tensor],
-    max_error: float = 1e-5,
-    max_rank: int = 1024,
+    config: Optional[MPSConfig] = None,
 ) -> list[torch.tensor]:
     """
     Returns a new matrix product, resulting from applying `top` to `bottom`.
@@ -136,6 +139,8 @@ def zip_right(
         A final truncation sweep, from right to left,
         moves back the orthogonal center to the first element.
     """
+    config = config if config is not None else MPSConfig()
+
     if len(top_factors) != len(bottom_factors):
         raise ValueError("Cannot multiply two matrix products of different lengths.")
 
@@ -146,6 +151,6 @@ def zip_right(
         new_factors.append(res)
     new_factors[-1] @= slider[:, :, 0]
 
-    truncate_impl(new_factors, max_error=max_error, max_rank=max_rank)
+    truncate_impl(new_factors, config=config)
 
     return new_factors

--- a/emu_mps/constants.py
+++ b/emu_mps/constants.py
@@ -1,0 +1,4 @@
+import torch
+
+
+DEVICE_COUNT = torch.cuda.device_count()

--- a/emu_mps/hamiltonian.py
+++ b/emu_mps/hamiltonian.py
@@ -285,6 +285,7 @@ def _get_interactions_to_keep(interaction_matrix: torch.Tensor) -> list[torch.Te
     returns a list of bool valued tensors,
     indicating which interaction terms to keep for each bond in the MPO
     """
+    interaction_matrix = interaction_matrix.clone()
     nqubits = interaction_matrix.size(dim=1)
     middle = nqubits // 2
     interaction_matrix += torch.eye(

--- a/emu_mps/mpo.py
+++ b/emu_mps/mpo.py
@@ -8,7 +8,8 @@ from emu_mps.algebra import add_factors, scale_factors, zip_right
 from emu_base.base_classes.operator import FullOp, QuditOp
 from emu_base import Operator, State
 from emu_mps.mps import MPS
-from emu_mps.utils import new_left_bath, assign_devices, DEVICE_COUNT
+from emu_mps.utils import new_left_bath, assign_devices
+from emu_mps.constants import DEVICE_COUNT
 
 
 def _validate_operator_targets(operations: FullOp, nqubits: int) -> None:
@@ -80,8 +81,7 @@ class MPO(Operator):
         factors = zip_right(
             self.factors,
             other.factors,
-            max_error=other.precision,
-            max_rank=other.max_bond_dim,
+            config=other.config,
         )
         return MPS(factors, orthogonality_center=0)
 

--- a/emu_mps/mps_backend.py
+++ b/emu_mps/mps_backend.py
@@ -1,8 +1,12 @@
-from pulser import Sequence
-
 from emu_base import Backend, BackendConfig, Results
 from emu_mps.mps_config import MPSConfig
-from emu_mps.mps_backend_impl import create_impl
+from emu_mps.mps_backend_impl import create_impl, MPSBackendImpl
+from pulser import Sequence
+import pickle
+import os
+import time
+import logging
+import pathlib
 
 
 class MPSBackend(Backend):
@@ -10,6 +14,32 @@ class MPSBackend(Backend):
     A backend for emulating Pulser sequences using Matrix Product States (MPS),
     aka tensor trains.
     """
+
+    def resume(self, autosave_file: str | pathlib.Path) -> Results:
+        """
+        Resume simulation from autosave file.
+        Only resume simulations from data you trust!
+        Unpickling of untrusted data is not safe.
+        """
+        if isinstance(autosave_file, str):
+            autosave_file = pathlib.Path(autosave_file)
+
+        if not autosave_file.is_file():
+            raise ValueError(f"Not a file: {autosave_file}")
+
+        with open(autosave_file, "rb") as f:
+            impl: MPSBackendImpl = pickle.load(f)
+
+        impl.autosave_file = autosave_file
+        impl.last_save_time = time.time()
+        impl.config.init_logging()  # FIXME: might be best to take logger object out of config.
+
+        logging.getLogger("global_logger").warning(
+            f"Resuming simulation from file {autosave_file}\n"
+            f"Saving simulation state every {impl.config.autosave_dt} seconds"
+        )
+
+        return self._run(impl)
 
     def run(self, sequence: Sequence, mps_config: BackendConfig) -> Results:
         """
@@ -29,7 +59,14 @@ class MPSBackend(Backend):
         impl = create_impl(sequence, mps_config)
         impl.init()  # This is separate from the constructor for testing purposes.
 
+        return self._run(impl)
+
+    @staticmethod
+    def _run(impl: MPSBackendImpl) -> Results:
         while not impl.is_finished():
             impl.progress()
+
+        if impl.autosave_file.is_file():
+            os.remove(impl.autosave_file)
 
         return impl.results

--- a/emu_mps/mps_config.py
+++ b/emu_mps/mps_config.py
@@ -1,7 +1,7 @@
 from typing import Any
 
 from emu_base import BackendConfig, State
-from emu_mps.utils import DEVICE_COUNT
+from emu_mps.constants import DEVICE_COUNT
 
 
 class MPSConfig(BackendConfig):
@@ -23,6 +23,10 @@ class MPSConfig(BackendConfig):
         num_gpus_to_use: during the simulation, distribute the state over this many GPUs
             0=all factors to cpu. As shown in the benchmarks, using multiple GPUs might
             alleviate memory pressure per GPU, but the runtime should be similar.
+        autosave_prefix: filename prefix for autosaving simulation state to file
+        autosave_dt: minimum time interval in seconds between two autosaves
+            Saving the simulation state is only possible at specific times,
+            therefore this interval is only a lower bound.
         kwargs: arguments that are passed to the base class
 
     Examples:
@@ -43,6 +47,8 @@ class MPSConfig(BackendConfig):
         max_krylov_dim: int = 100,
         extra_krylov_tolerance: float = 1e-3,
         num_gpus_to_use: int = DEVICE_COUNT,
+        autosave_prefix: str = "emu_mps_save_",
+        autosave_dt: int = 600,  # 10 minutes
         **kwargs: Any,
     ):
         super().__init__(**kwargs)
@@ -62,3 +68,11 @@ class MPSConfig(BackendConfig):
                 and self.noise_model.amp_sigma != 0.0
             ):
                 raise NotImplementedError("Unsupported noise type: amp_sigma")
+
+        self.autosave_prefix = autosave_prefix
+        self.autosave_dt = autosave_dt
+
+        MIN_AUTOSAVE_DT = 10
+        assert (
+            self.autosave_dt > MIN_AUTOSAVE_DT
+        ), f"autosave_dt must be larger than {MIN_AUTOSAVE_DT} seconds"

--- a/emu_mps/utils.py
+++ b/emu_mps/utils.py
@@ -3,7 +3,7 @@ import torch
 import random
 from collections import Counter
 
-DEVICE_COUNT = torch.cuda.device_count()
+from emu_mps import MPSConfig
 
 
 def new_left_bath(
@@ -61,8 +61,7 @@ def split_tensor(
 
 def truncate_impl(
     factors: list[torch.tensor],
-    max_error: float = 1e-5,
-    max_rank: int = 1024,
+    config: MPSConfig,
 ) -> None:
     """
     Eigenvalues-based truncation of a matrix product.
@@ -78,8 +77,8 @@ def truncate_impl(
 
         l, r = split_tensor(
             factors[i].reshape(factor_shape[0], -1),
-            max_error=max_error,
-            max_rank=max_rank,
+            max_error=config.precision,
+            max_rank=config.max_bond_dim,
             orth_center_right=False,
         )
 
@@ -241,7 +240,7 @@ def apply_measurement_errors(
     return result
 
 
-n_operator = torch.tensor(
+n_operator: torch.Tensor = torch.tensor(
     [
         [0, 0],
         [0, 1],

--- a/test/emu_mps/test_endtoend.py
+++ b/test/emu_mps/test_endtoend.py
@@ -1,3 +1,4 @@
+import time
 from unittest.mock import ANY, MagicMock, patch
 
 import pulser
@@ -21,6 +22,7 @@ from emu_mps import (
 
 import pulser.noise_model
 
+from emu_mps.mps_backend_impl import MPSBackendImpl
 from test.utils_testing import (
     pulser_afm_sequence_grid,
     pulser_afm_sequence_ring,
@@ -465,3 +467,64 @@ def test_laser_waist():
     )
 
     assert pytest.approx(final_state.inner(expected_state)) == -1.0
+
+
+def test_autosave():
+    duration = 300
+    rows, cols = 2, 3
+    reg = pulser.Register.rectangle(
+        rows, cols, pulser.devices.MockDevice.rydberg_blockade_radius(U), prefix="q"
+    )
+    seq = pulser.Sequence(reg, pulser.devices.MockDevice)
+    seq.declare_channel("ising_global", "rydberg_global")
+    seq.add(
+        pulser.Pulse.ConstantAmplitude(
+            amplitude=torch.pi,
+            detuning=pulser.waveforms.ConstantWaveform(duration=duration, value=0.0),
+            phase=0.0,
+        ),
+        "ising_global",
+    )
+
+    evaluation_times = {10, 100, 150}
+    energy = emu_base.Energy(evaluation_times=evaluation_times)
+
+    save_simulation_original = MPSBackendImpl.save_simulation
+    save_file = None
+
+    counter = 100  # Number of simulation steps before crashing
+
+    def save_simulation_mock_side_effect(self):
+        nonlocal counter
+        counter -= 1
+        if counter > 0:
+            self.last_save_time = time.time() + 999
+            return save_simulation_original(self)
+
+        assert self.timestep_index == 11
+
+        self.last_save_time = 0  # Trigger saving regardless of time
+        save_simulation_original(self)
+        nonlocal save_file
+        save_file = self.autosave_file
+        raise Exception("Process killed!")
+
+    with patch.object(
+        MPSBackendImpl, "save_simulation", autospec=True
+    ) as save_simulation_mock:
+        save_simulation_mock.side_effect = save_simulation_mock_side_effect
+
+        with pytest.raises(Exception) as e:
+            MPSBackend().run(seq, MPSConfig(observables=[energy]))
+
+        assert str(e.value) == "Process killed!"
+
+    assert save_file is not None and save_file.is_file()
+    results_after_resume = MPSBackend().resume(save_file)
+
+    assert not save_file.is_file()
+
+    results_expected = MPSBackend().run(seq, MPSConfig(observables=[energy]))
+
+    for t in evaluation_times:
+        assert results_after_resume["energy", t] == results_expected["energy", t]

--- a/test/emu_mps/test_mps_backend_impl.py
+++ b/test/emu_mps/test_mps_backend_impl.py
@@ -241,8 +241,8 @@ def test_init_initial_state_default(pick_well_prepared_qubits_mock):
         torch.allclose(factor1, factor2)
         for factor1, factor2 in zip(expected.factors, victim.state.factors)
     )
-    assert victim.state.precision == 0.001
-    assert victim.state.max_bond_dim == 100
+    assert victim.state.config.precision == 0.001
+    assert victim.state.config.max_bond_dim == 100
 
 
 def test_init_initial_state_provided_filter():

--- a/test/emu_mps/test_tdvp.py
+++ b/test/emu_mps/test_tdvp.py
@@ -1,11 +1,10 @@
 import torch
 from emu_base.math import krylov_exp
-from emu_mps import MPS, MPO
+from emu_mps import MPS, MPO, MPSConfig
 from emu_mps.tdvp import (
     apply_effective_Hamiltonian,
     right_baths,
     evolve_single,
-    EvolveConfig,
     evolve_pair,
 )
 
@@ -211,14 +210,10 @@ def test_evolve_single():
         baths=(left_bath, right_bath),
         ham_factor=ham_factor,
         dt=dt,
-        config=EvolveConfig(
-            exp_tolerance=1e-8,
-            norm_tolerance=1e-8,
-            max_krylov_dim=100,
-            is_hermitian=False,
-            max_error=1e-5,
-            max_rank=10,  # FIXME: max_error and max_rank are irrelevant for evolve_single
+        config=MPSConfig(
+            max_bond_dim=10,
         ),
+        is_hermitian=False,
     )
 
     assert torch.allclose(expected, actual, rtol=0, atol=1e-8)
@@ -251,18 +246,14 @@ def test_evolve_pair():
     ).reshape(3, 2, 2, 5)
 
     actual_left, actual_right = evolve_pair(
-        state_factors=(left_state_factor, right_state_factor),
+        state_factors=[left_state_factor, right_state_factor],
         baths=(left_bath, right_bath),
-        ham_factors=(left_ham_factor, right_ham_factor),
+        ham_factors=[left_ham_factor, right_ham_factor],
         dt=dt,
-        config=EvolveConfig(
-            exp_tolerance=1e-8,
-            norm_tolerance=1e-8,
-            max_krylov_dim=100,
-            is_hermitian=False,
-            max_error=1e-5,
-            max_rank=10,  # FIXME: max_error and max_rank are irrelevant for evolve_single
+        config=MPSConfig(
+            max_bond_dim=10,
         ),
+        is_hermitian=False,
         orth_center_right=False,
     )
 


### PR DESCRIPTION
- Adds autosave_prefix and autosave_dt config fields
	By default:
               `emu_mps_save_<uuid>.dat`
		every 10 minute
- Accidentally fix the various config entries and
carry the whole MPSConfig along. It was part of my
research for optimal implementation and takes too
much time to separate as a independent MR.
- Some fixes to the unpickled impl are necessary,
like autosave_file (to save to same existing file)
and the logger which gets messed up by the pickling.
- Fix make_H modifying its interaction_matrix argument.
That was also part of the process but in fact now
unrelated.

---> How to resume a simulation from a file

```
import emu_mps
results = emu_mps.MPSBackend().resume("emu_mps_save_xxx.dat")
```