### PR TITLE
fix emu-base dependency

### DIFF
--- a/.github/workflows/lint_test.yml
+++ b/.github/workflows/lint_test.yml
@@ -15,8 +15,14 @@ jobs:
       - run: pip install pre-commit pyproject-flake8
       - run: pre-commit install
       - run: pre-commit run --all-files
-  test:
+  check_dependency_versions:
     needs: lint
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - run: ./test_dependency_versions.sh
+  test:
+    needs: check_dependency_versions
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4

--- a/ci/emu_mps/pyproject.toml
+++ b/ci/emu_mps/pyproject.toml
@@ -23,7 +23,7 @@ classifiers=[
 ]
 dynamic = ["version"]
 dependencies = [
-  "emu-base==1.2.0"]
+  "emu-base==1.2.2"]
 
 [tool.hatch.version]
 path = "../../emu_mps/__init__.py"

--- a/emu_base/__init__.py
+++ b/emu_base/__init__.py
@@ -44,4 +44,4 @@ __all__ = [
     "DEFAULT_MAX_KRYLOV_DIM",
 ]
 
-__version__ = "1.2.3"
+__version__ = "1.2.2"

--- a/emu_base/__init__.py
+++ b/emu_base/__init__.py
@@ -44,4 +44,4 @@ __all__ = [
     "DEFAULT_MAX_KRYLOV_DIM",
 ]
 
-__version__ = "1.2.2"
+__version__ = "1.2.3"

--- a/emu_base/__init__.py
+++ b/emu_base/__init__.py
@@ -44,4 +44,4 @@ __all__ = [
     "DEFAULT_MAX_KRYLOV_DIM",
 ]
 
-__version__ = "1.2.1"
+__version__ = "1.2.2"

--- a/emu_mps/__init__.py
+++ b/emu_mps/__init__.py
@@ -35,4 +35,4 @@ __all__ = [
     "SecondMomentOfEnergy",
 ]
 
-__version__ = "1.2.1"
+__version__ = "1.2.2"

--- a/test_dependency_versions.sh
+++ b/test_dependency_versions.sh
@@ -3,7 +3,7 @@
 mps_string=`grep emu-base ci/emu_mps/pyproject.toml`
 [[ "$mps_string" =~ .*([0-9]\.[0-9]\.[0-9]).* ]]
 mps_dep=${BASH_REMATCH[1]}
-echo mps depends on emu-base version $mps_dep
+echo emu-mps depends on emu-base version $mps_dep
 
 base_string=`grep version emu_base/__init__.py`
 [[ "$base_string" =~ .*([0-9]\.[0-9]\.[0-9]).* ]]

--- a/test_dependency_versions.sh
+++ b/test_dependency_versions.sh
@@ -1,12 +1,15 @@
 #!/bin/bash
+
 mps_string=`grep emu-base ci/emu_mps/pyproject.toml`
 [[ "$mps_string" =~ .*([0-9]\.[0-9]\.[0-9]).* ]]
 mps_dep=${BASH_REMATCH[1]}
 echo mps depends on emu-base version $mps_dep
+
 base_string=`grep version emu_base/__init__.py`
 [[ "$base_string" =~ .*([0-9]\.[0-9]\.[0-9]).* ]]
 base_version=${BASH_REMATCH[1]}
 echo emu-base is version $base_version
+
 if [[ $mps_dep == $base_version ]]
 then
 exit 0

--- a/test_dependency_versions.sh
+++ b/test_dependency_versions.sh
@@ -1,0 +1,14 @@
+mps_string=`grep emu-base ci/emu_mps/pyproject.toml`
+[[ "$mps_string" =~ .*([0-9]\.[0-9]\.[0-9]).* ]]
+mps_dep=${BASH_REMATCH[1]}
+echo mps depends on emu-base version $mps_dep
+base_string=`grep version emu_base/__init__.py`
+[[ "$base_string" =~ .*([0-9]\.[0-9]\.[0-9]).* ]]
+base_version=${BASH_REMATCH[1]}
+echo emu-base is version $base_version
+if [[ $mps_dep == $base_version ]]
+then
+exit 0
+else
+exit 1
+fi

--- a/test_dependency_versions.sh
+++ b/test_dependency_versions.sh
@@ -1,3 +1,4 @@
+#!/bin/bash
 mps_string=`grep emu-base ci/emu_mps/pyproject.toml`
 [[ "$mps_string" =~ .*([0-9]\.[0-9]\.[0-9]).* ]]
 mps_dep=${BASH_REMATCH[1]}


### PR DESCRIPTION
The newly released emu-mps v1.2.1 depends on emu-base v1.2.0 which is not correct. Fix the dependency.