### PR TITLE
improve discretization

### DIFF
--- a/emu_base/pulser_adapter.py
+++ b/emu_base/pulser_adapter.py
@@ -158,17 +158,26 @@ def _extract_omega_delta_phi(
                 global_times |= set(i for i in range(slot.ti, slot.tf))
 
     step = 0
-    t = int((step + 1 / 2) * dt)
+    t = (step + 1 / 2) * dt
 
     while t < max_duration:
         for q_pos, q_id in enumerate(sequence.register.qubit_ids):
-            omega[step, q_pos] = locals_a_d_p[q_id]["amp"][t]
-            delta[step, q_pos] = locals_a_d_p[q_id]["det"][t]
-            phi[step, q_pos] = locals_a_d_p[q_id]["phase"][t]
+            omega[step, q_pos] = (
+                locals_a_d_p[q_id]["amp"][math.floor(t)]
+                + locals_a_d_p[q_id]["amp"][math.ceil(t)]
+            ) / 2.0
+            delta[step, q_pos] = (
+                locals_a_d_p[q_id]["det"][math.floor(t)]
+                + locals_a_d_p[q_id]["det"][math.ceil(t)]
+            ) / 2.0
+            phi[step, q_pos] = (
+                locals_a_d_p[q_id]["phase"][math.floor(t)]
+                + locals_a_d_p[q_id]["phase"][math.ceil(t)]
+            ) / 2.0
         if t in global_times:
             omega[step] *= waist_factors
         step += 1
-        t = int((step + 1 / 2) * dt)
+        t = (step + 1 / 2) * dt
 
     return omega, delta, phi
 


### PR DESCRIPTION
While finishing the emu-sv benchmarks, I was disturbed by the following graph:
![emu_sv_afm_state_fidelity_odd](https://github.com/user-attachments/assets/3fa0a1eb-6338-4020-999a-2964ac93251d)
I would expect qubit densities to become more similar to pulser with lower dt, because the assumption of piecewise constant Hamiltonian becomes less discontinuous. Some investigation shows that the problem only occurs for odd dt. I made a change in the discretization logic for odd dt, and now the graph is as follows:
![emu_sv_afm_state_fidelity](https://github.com/user-attachments/assets/f005f794-dd63-486a-ae87-edced3041cee)
