### PR TITLE
pulser core 1.3 + validation

### DIFF
--- a/ci/emu_base/pyproject.toml
+++ b/ci/emu_base/pyproject.toml
@@ -21,7 +21,7 @@ classifiers=[
     "Programming Language :: Python :: Implementation :: PyPy",
 ]
 dependencies = [
-  "pulser-core==1.1.*",
+  "pulser-core==1.3.*",
   "torch==2.5.0"]
 dynamic = ["version"]
 

--- a/ci/emu_mps/pyproject.toml
+++ b/ci/emu_mps/pyproject.toml
@@ -22,7 +22,7 @@ classifiers=[
 ]
 dynamic = ["version"]
 dependencies = [
-  "emu-base==1.2.4"]
+  "emu-base==1.2.5"]
 
 [tool.hatch.version]
 path = "../../emu_mps/__init__.py"

--- a/emu_base/__init__.py
+++ b/emu_base/__init__.py
@@ -44,4 +44,4 @@ __all__ = [
     "DEFAULT_MAX_KRYLOV_DIM",
 ]
 
-__version__ = "1.2.4"
+__version__ = "1.2.5"

--- a/emu_mps/__init__.py
+++ b/emu_mps/__init__.py
@@ -35,4 +35,4 @@ __all__ = [
     "SecondMomentOfEnergy",
 ]
 
-__version__ = "1.2.4"
+__version__ = "1.2.5"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,7 +20,7 @@ classifiers=[
     "Programming Language :: Python :: Implementation :: PyPy",
 ]
 dependencies = [
-  "pulser-core==1.2.*",
+  "pulser-core==1.3.*",
   "torch==2.5.0"]  # The version in .pre-commit-config.yaml must match
 dynamic = ["version"]
 

--- a/test_dependency_versions.sh
+++ b/test_dependency_versions.sh
@@ -16,6 +16,21 @@ then
     exit 1
 fi
 
+pulser_root_string="$(grep pulser-core pyproject.toml)"
+[[ "$pulser_root_string" =~ .*([0-9]\.[0-9\*]\.[0-9\*]).* ]]
+pulser_root_dep="${BASH_REMATCH[1]}"
+echo "The root package depends on pulser-core version $pulser_root_dep"
+
+pulser_base_string="$(grep pulser-core ci/emu_base/pyproject.toml)"
+[[ "$pulser_base_string" =~ .*([0-9]\.[0-9\*]\.[0-9\*]).* ]]
+pulser_base_dep="${BASH_REMATCH[1]}"
+echo "emu-base depends on pulser-core version $pulser_base_dep"
+
+if [[ "$pulser_root_dep" != "$pulser_base_dep" ]]
+then
+    exit 1
+fi
+
 torch_pre_commit_string="$(grep torch .pre-commit-config.yaml)"
 [[ "$torch_pre_commit_string" =~ .*([0-9]\.[0-9]\.[0-9]).* ]]
 torch_pre_commit_version="${BASH_REMATCH[1]}"


### PR DESCRIPTION
Make everything depend on pulser-core 1.3.*
Extend the shell script to validate that the dev and published packages depend on the same version.