### PR TITLE
improve dark mode hyperlinks

### DIFF
--- a/emu_sv/state_vector.py
+++ b/emu_sv/state_vector.py
@@ -127,7 +127,6 @@ class StateVector(State):
         """
 
         probabilities = torch.abs(self.vector) ** 2
-        probabilities /= probabilities.sum()  # multinomial does not normalize the input
 
         outcomes = torch.multinomial(probabilities, num_shots, replacement=True)
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -64,7 +64,7 @@ theme:
       name: Switch to dark mode
   - media: "(prefers-color-scheme: dark)"
     scheme: slate
-    primary: custom
+    primary: black
     accent: custom
     toggle:
       icon: material/weather-night


### PR DESCRIPTION
Solves #60 In dark mode, hyperlinks in the documentation were not easily visible. I changed it to this:
![image](https://github.com/user-attachments/assets/4c0904f5-04ff-40fb-bb79-11c658d5415f)
