### PR TITLE
add results encoder

### DIFF
--- a/emu_base/base_classes/results.py
+++ b/emu_base/base_classes/results.py
@@ -3,9 +3,17 @@ from typing import Any, Callable, Optional
 from pathlib import Path
 import json
 import logging
+import torch
 
 from emu_base.base_classes.callback import Callback, AggregationType
 from emu_base.base_classes.aggregators import aggregation_types_definitions
+
+
+class ResultsEncoder(json.JSONEncoder):
+    def default(self, obj: Any) -> Any:
+        if isinstance(obj, torch.Tensor):
+            return obj.tolist()
+        return super().default(obj)
 
 
 @dataclass
@@ -171,4 +179,5 @@ class Results:
                     "statistics": self.statistics,
                 },
                 file_handle,
+                cls=ResultsEncoder,
             )


### PR DESCRIPTION
2 of the benchmarks are failing, because emu-sv now returns `torch.Tensor` objects for a few of the results.
These do not serialize by default, so a call to `json.dump` fails. I'm adding an encoder to `Results.dump` so that the serialization works again.