### PR TITLE
support irregular target times

### DIFF
--- a/docs/emu_mps/notebooks/getting_started.ipynb
+++ b/docs/emu_mps/notebooks/getting_started.ipynb
@@ -203,8 +203,8 @@
    "source": [
     "dt = 100\n",
     "final_time = (\n",
-    "    seq.get_duration() // dt * dt\n",
-    ")  # final_time should be a multiple of dt, and not exceed the sequence duration\n",
+    "    seq.get_duration()\n",
+    ")\n",
     "eval_times = [final_time]\n",
     "\n",
     "basis = {\n",

--- a/emu_base/pulser_adapter.py
+++ b/emu_base/pulser_adapter.py
@@ -88,7 +88,7 @@ def _xy_interaction(sequence: pulser.Sequence) -> torch.Tensor:
 def _extract_omega_delta_phi(
     *,
     sequence: pulser.Sequence,
-    dt: int,
+    target_times: list[int],
     with_modulation: bool,
     laser_waist: float | None,
 ) -> Tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
@@ -125,7 +125,7 @@ def _extract_omega_delta_phi(
 
     max_duration = sequence.get_duration(include_fall_time=with_modulation)
 
-    nsamples = math.ceil(max_duration / dt - 1 / 2)
+    nsamples = len(target_times) - 1
     omega = torch.zeros(
         nsamples,
         len(sequence.register.qubit_ids),
@@ -157,12 +157,11 @@ def _extract_omega_delta_phi(
             for slot in ch_samples.slots:
                 global_times |= set(i for i in range(slot.ti, slot.tf))
 
-    step = 0
-    t = (step + 1 / 2) * dt
     omega_1 = torch.zeros_like(omega[0])
     omega_2 = torch.zeros_like(omega[0])
 
-    while t < max_duration:
+    for i in range(nsamples):
+        t = (target_times[i] + target_times[i + 1]) / 2
         # The sampled values correspond to the start of each interval
         # To maximize the order of the solver, we need the values in the middle
         if math.ceil(t) < max_duration:
@@ -173,10 +172,10 @@ def _extract_omega_delta_phi(
                 t2 = math.ceil(t)
                 omega_1[q_pos] = locals_a_d_p[q_id]["amp"][t1]
                 omega_2[q_pos] = locals_a_d_p[q_id]["amp"][t2]
-                delta[step, q_pos] = (
+                delta[i, q_pos] = (
                     locals_a_d_p[q_id]["det"][t1] + locals_a_d_p[q_id]["det"][t2]
                 ) / 2.0
-                phi[step, q_pos] = (
+                phi[i, q_pos] = (
                     locals_a_d_p[q_id]["phase"][t1] + locals_a_d_p[q_id]["phase"][t2]
                 ) / 2.0
             # omegas at different times need to have the laser waist applied independently
@@ -184,21 +183,19 @@ def _extract_omega_delta_phi(
                 omega_1 *= waist_factors
             if t2 in global_times:
                 omega_2 *= waist_factors
-            omega[step] = 0.5 * (omega_1 + omega_2)
+            omega[i] = 0.5 * (omega_1 + omega_2)
         else:
             # We're in the final step and dt=1, approximate this using linear extrapolation
             # we can reuse omega_1 and omega_2 from before
             for q_pos, q_id in enumerate(sequence.register.qubit_ids):
-                delta[step, q_pos] = (
+                delta[i, q_pos] = (
                     3.0 * locals_a_d_p[q_id]["det"][t2] - locals_a_d_p[q_id]["det"][t1]
                 ) / 2.0
-                phi[step, q_pos] = (
+                phi[i, q_pos] = (
                     3.0 * locals_a_d_p[q_id]["phase"][t2]
                     - locals_a_d_p[q_id]["phase"][t1]
                 ) / 2.0
-            omega[step] = torch.clamp(0.5 * (3 * omega_2 - omega_1).real, min=0.0)
-        step += 1
-        t = (step + 1 / 2) * dt
+            omega[i] = torch.clamp(0.5 * (3 * omega_2 - omega_1).real, min=0.0)
 
     return omega, delta, phi
 
@@ -233,12 +230,20 @@ class PulserData:
     def __init__(self, *, sequence: pulser.Sequence, config: BackendConfig, dt: int):
         self.qubit_count = len(sequence.register.qubit_ids)
 
+        # the end value is exclusive, so add +1
+        observable_times = set(torch.arange(0, sequence.get_duration() + 1, dt).tolist())
+        observable_times.add(sequence.get_duration())
+        for obs in config.callbacks:
+            observable_times |= set(obs.evaluation_times)
+        self.target_times = list(observable_times)
+        self.target_times.sort()
+
         laser_waist = (
             config.noise_model.laser_waist if config.noise_model is not None else None
         )
         self.omega, self.delta, self.phi = _extract_omega_delta_phi(
             sequence=sequence,
-            dt=dt,
+            target_times=self.target_times,
             with_modulation=config.with_modulation,
             laser_waist=laser_waist,
         )

--- a/examples/emu_mps/interaction_matrix.py
+++ b/examples/emu_mps/interaction_matrix.py
@@ -57,11 +57,11 @@ seq.add(fall, "ising_global")
 sim = MPSBackend()
 
 # Configuration for the Backend and for observables
-dt = 100  # time step for discretization, by the default: dt =10
+dt = 99  # time step for discretization, by the default: dt =10
 
 # information for the observables
 
-final_time = seq.get_duration() // dt * dt
+final_time = seq.get_duration()
 # Calculate the final time of the sequence. Some observables will be measured at time steps
 # that are multiples of dt.  Using integer division // ensures time steps align with dt.
 # NOTE: The sequence is discretized by dt, so the state evolves at these time steps.

--- a/examples/emu_mps/interaction_matrix.py
+++ b/examples/emu_mps/interaction_matrix.py
@@ -57,18 +57,13 @@ seq.add(fall, "ising_global")
 sim = MPSBackend()
 
 # Configuration for the Backend and for observables
-dt = 99  # time step for discretization, by the default: dt =10
+dt = 100  # time step for discretization, by the default: dt =10
 
 # information for the observables
 
 final_time = seq.get_duration()
-# Calculate the final time of the sequence. Some observables will be measured at time steps
-# that are multiples of dt.  Using integer division // ensures time steps align with dt.
-# NOTE: The sequence is discretized by dt, so the state evolves at these time steps.
 
 times = {final_time}  # final step for an observable to be measure
-# all the times have to be a multiple of dt
-
 
 # As an example, we are going to create an antiferromagnetic (afm) state (mps) and
 # a suporpostion of afm states in order to calculate the

--- a/test/emu_base/test_adapter.py
+++ b/test/emu_base/test_adapter.py
@@ -369,7 +369,6 @@ def test_extract_omega_delta_phi_dt_1(
     TEST_DURATION = 13
     dt = 1
     target_times = torch.arange(0, TEST_DURATION + 1, dt).tolist()
-    print(target_times)
     sequence.get_duration.return_value = TEST_DURATION
 
     if laser_waist is not None:

--- a/test/emu_base/test_adapter.py
+++ b/test/emu_base/test_adapter.py
@@ -283,6 +283,7 @@ def test_extract_omega_delta_phi_dt_2(
     Global pulse: Pulse(RampWaveform(8,10.0,0.0),RampWaveform(8,-10,10),0.2)"""
     TEST_DURATION = 13
     dt = 2
+    target_times = torch.arange(0, TEST_DURATION + 1, dt).tolist()
     sequence.get_duration.return_value = TEST_DURATION
 
     if laser_waist is not None:
@@ -298,7 +299,10 @@ def test_extract_omega_delta_phi_dt_2(
     mock_pulser_sample.return_value = mock_sample(hamiltonian_type)
 
     actual_omega, actual_delta, actual_phi = _extract_omega_delta_phi(
-        sequence=sequence, dt=dt, with_modulation=False, laser_waist=laser_waist
+        sequence=sequence,
+        target_times=target_times,
+        with_modulation=False,
+        laser_waist=laser_waist,
     )
 
     expected_number_of_samples = math.ceil(TEST_DURATION / dt - 0.5)
@@ -364,6 +368,8 @@ def test_extract_omega_delta_phi_dt_1(
     Global pulse: Pulse(RampWaveform(8,10.0,0.0),RampWaveform(8,-10,10),0.2)"""
     TEST_DURATION = 13
     dt = 1
+    target_times = torch.arange(0, TEST_DURATION + 1, dt).tolist()
+    print(target_times)
     sequence.get_duration.return_value = TEST_DURATION
 
     if laser_waist is not None:
@@ -382,7 +388,10 @@ def test_extract_omega_delta_phi_dt_1(
     mock_pulser_sample.return_value = mock_sample(hamiltonian_type)
 
     actual_omega, actual_delta, actual_phi = _extract_omega_delta_phi(
-        sequence=sequence, dt=dt, with_modulation=False, laser_waist=laser_waist
+        sequence=sequence,
+        target_times=target_times,
+        with_modulation=False,
+        laser_waist=laser_waist,
     )
 
     expected_number_of_samples = math.ceil(TEST_DURATION / dt - 0.5)
@@ -523,6 +532,7 @@ def test_extract_omega_delta_phi_dt_1(
 def test_autograd(mock_pulser_sample):
     TEST_DURATION = 10
     dt = 2
+    target_times = torch.arange(0, TEST_DURATION + 1, dt).tolist()
     sequence.get_duration.return_value = TEST_DURATION
     amp_tensor = torch.tensor(
         [
@@ -589,7 +599,10 @@ def test_autograd(mock_pulser_sample):
 
     # first data for grad
     omega_value = _extract_omega_delta_phi(
-        sequence=sequence, dt=dt, with_modulation=False, laser_waist=None
+        sequence=sequence,
+        target_times=target_times,
+        with_modulation=False,
+        laser_waist=None,
     )[0][2, 2].real
 
     # second data to for grad
@@ -687,6 +700,7 @@ def test_get_all_lindblad_operators():
 def test_parsed_sequence(mock_pulser_sample):
     TEST_DURATION = 10
     dt = 2
+    target_times = torch.arange(0, TEST_DURATION + 1, dt).tolist()
     sequence.get_duration.return_value = TEST_DURATION
     amp_tensor = torch.tensor(
         [
@@ -772,7 +786,10 @@ def test_parsed_sequence(mock_pulser_sample):
 
     parsed_sequence = PulserData(sequence=sequence, config=config, dt=dt)
     omega, delta, phi = _extract_omega_delta_phi(
-        sequence=sequence, dt=dt, with_modulation=False, laser_waist=None
+        sequence=sequence,
+        target_times=target_times,
+        with_modulation=False,
+        laser_waist=None,
     )
 
     cutoff_interaction_matrix = torch.tensor(
@@ -801,7 +818,10 @@ def test_parsed_sequence(mock_pulser_sample):
 
     parsed_sequence = PulserData(sequence=sequence, config=config, dt=dt)
     omega, delta, phi = _extract_omega_delta_phi(
-        sequence=sequence, dt=dt, with_modulation=False, laser_waist=None
+        sequence=sequence,
+        target_times=target_times,
+        with_modulation=False,
+        laser_waist=None,
     )
 
     assert torch.allclose(parsed_sequence.omega, omega)
@@ -828,6 +848,7 @@ def test_laser_waist(mock_pulser_sample, mock_qubit_positions):
     ]
     TEST_DURATION = 10
     dt = 2
+    target_times = torch.arange(0, TEST_DURATION + 1, dt).tolist()
     sequence.get_duration.return_value = TEST_DURATION
     adressed_basis = "XY"
     sequence.get_addressed_bases.return_value = [adressed_basis]
@@ -849,7 +870,10 @@ def test_laser_waist(mock_pulser_sample, mock_qubit_positions):
     )
     parsed_sequence = PulserData(sequence=sequence, config=config, dt=dt)
     omega, delta, phi = _extract_omega_delta_phi(
-        sequence=sequence, dt=dt, with_modulation=False, laser_waist=0.1
+        sequence=sequence,
+        target_times=target_times,
+        with_modulation=False,
+        laser_waist=0.1,
     )
     assert torch.allclose(omega, parsed_sequence.omega)
     assert torch.allclose(delta, parsed_sequence.delta)


### PR DESCRIPTION
In both emu-sv and emu-mps the time evolution code now takes a list of target times, and evolves from one target time to the other. The pulser adapter now also outputs a list of target times. Target times are now given as
- all multiples of dt
- augmented with the sequence duration
- augmented with the evaluation times of all the observables

This will make the emulation always emulate exactly the sequence duration, and also removes the issue where observables were not printed if they weren't  evaluated at a multiple of dt.