### PR TITLE
Fix baths not being updated after quantum jump

### DIFF
--- a/emu_mps/mps_backend_impl.py
+++ b/emu_mps/mps_backend_impl.py
@@ -177,6 +177,12 @@ class MPSBackendImpl:
         self.right_baths = right_baths(self.state, self.hamiltonian, final_qubit=2)
         assert len(self.right_baths) == self.qubit_count - 1
 
+    def get_current_right_bath(self) -> torch.Tensor:
+        return self.right_baths[-1]
+
+    def get_current_left_bath(self) -> torch.Tensor:
+        return self.left_baths[-1]
+
     def init(self) -> None:
         self.init_dark_qubits()
         self.init_initial_state(self.config.initial_state)
@@ -197,7 +203,7 @@ class MPSBackendImpl:
         """
         assert 1 <= len(indices) <= 2
 
-        baths = (self.left_baths[-1], self.right_baths[-1])
+        baths = (self.get_current_left_bath(), self.get_current_right_bath())
 
         if len(indices) == 1:
             assert orth_center_right is None
@@ -269,7 +275,7 @@ class MPSBackendImpl:
             )
             self.left_baths.append(
                 new_left_bath(
-                    self.left_baths[-1],
+                    self.get_current_left_bath(),
                     self.state.factors[self.tdvp_index],
                     self.hamiltonian.factors[self.tdvp_index],
                 ).to(self.state.factors[self.tdvp_index + 1].device)
@@ -298,7 +304,7 @@ class MPSBackendImpl:
             assert self.tdvp_index <= self.qubit_count - 2
             self.right_baths.append(
                 new_right_bath(
-                    self.right_baths[-1],
+                    self.get_current_right_bath(),
                     self.state.factors[self.tdvp_index + 1],
                     self.hamiltonian.factors[self.tdvp_index + 1],
                 ).to(self.state.factors[self.tdvp_index].device)
@@ -535,6 +541,7 @@ class NoisyMPSBackendImpl(MPSBackendImpl):
         self.state.apply(jumped_qubit_index, jump_operator)
         self.state.orthogonalize(0)
         self.state *= 1 / self.state.norm()
+        self.init_baths()
 
         norm_after_normalizing = self.state.norm()
         assert math.isclose(norm_after_normalizing, 1, abs_tol=1e-10)

--- a/emu_mps/mps_backend_impl.py
+++ b/emu_mps/mps_backend_impl.py
@@ -486,12 +486,15 @@ class NoisyMPSBackendImpl(MPSBackendImpl):
         self.aggregated_lindblad_ops = stacked.conj().transpose(1, 2) @ stacked
 
         self.lindblad_noise = compute_noise_from_lindbladians(self.lindblad_ops)
+
+    def init_jump_threshold(self) -> None:
         self.jump_threshold = random.random()
         self.norm_gap_before_jump = self.state.norm() ** 2 - self.jump_threshold
 
     def init(self) -> None:
-        super().init()
         self.init_lindblad_noise()
+        super().init()
+        self.init_jump_threshold()
 
     def tdvp_complete(self) -> None:
         previous_time = self.current_time

--- a/emu_mps/mps_backend_impl.py
+++ b/emu_mps/mps_backend_impl.py
@@ -487,14 +487,14 @@ class NoisyMPSBackendImpl(MPSBackendImpl):
 
         self.lindblad_noise = compute_noise_from_lindbladians(self.lindblad_ops)
 
-    def init_jump_threshold(self) -> None:
-        self.jump_threshold = random.random()
+    def set_jump_threshold(self, bound: float) -> None:
+        self.jump_threshold = random.uniform(0.0, bound)
         self.norm_gap_before_jump = self.state.norm() ** 2 - self.jump_threshold
 
     def init(self) -> None:
         self.init_lindblad_noise()
         super().init()
-        self.init_jump_threshold()
+        self.set_jump_threshold(1.0)
 
     def tdvp_complete(self) -> None:
         previous_time = self.current_time
@@ -548,8 +548,7 @@ class NoisyMPSBackendImpl(MPSBackendImpl):
 
         norm_after_normalizing = self.state.norm()
         assert math.isclose(norm_after_normalizing, 1, abs_tol=1e-10)
-        self.jump_threshold = random.uniform(0.0, norm_after_normalizing**2)
-        self.norm_gap_before_jump = norm_after_normalizing**2 - self.jump_threshold
+        self.set_jump_threshold(norm_after_normalizing**2)
 
     def fill_results(self) -> None:
         # Remove the noise from self.hamiltonian for the callbacks.

--- a/test/emu_mps/test_endtoend.py
+++ b/test/emu_mps/test_endtoend.py
@@ -469,7 +469,6 @@ def test_end_to_end_spontaneous_emission():
     final_time = seq.get_duration()
     final_state = result["state"][final_time]
 
-    print(final_state)
     assert get_proba(final_state, "100000110000") == approx(1, abs=1e-2)
 
     # Aggregating results of many runs to check the exponential decrease of qubit density
@@ -509,23 +508,17 @@ def test_end_to_end_spontaneous_emission_rate():
         )
 
     final_time = seq.get_duration()
+    counts = {}
     # round probabilities to merge 1.0 and 0.9999999999999998 etc.
-    c = Counter(
-        [round(get_proba(result["state"][final_time], "11")) for result in results]
-    )
-    assert c[1] == 16  # true rate 0.135
-    c = Counter(
-        [round(get_proba(result["state"][final_time], "01")) for result in results]
-    )
-    assert c[1] == 17  # true rate 0.233
-    c = Counter(
-        [round(get_proba(result["state"][final_time], "10")) for result in results]
-    )
-    assert c[1] == 23  # true rate 0.233
-    c = Counter(
-        [round(get_proba(result["state"][final_time], "00")) for result in results]
-    )
-    assert c[1] == 44  # true rate 0.400
+    for string in ["00", "01", "10", "11"]:
+        counts[string] = Counter(
+            [round(get_proba(result["state"][final_time], string)) for result in results]
+        )[1]
+
+    # the exact rates are {"11":0.135, "01":0.233, "10":0.233, "00":0.400}
+    expected_counts = {"11": 16, "01": 17, "10": 23, "00": 44}
+
+    assert counts == expected_counts
 
 
 def test_laser_waist():

--- a/test/emu_mps/test_mps_backend_impl.py
+++ b/test/emu_mps/test_mps_backend_impl.py
@@ -182,12 +182,8 @@ def test_init_dark_qubits_with_state_prep_error(pick_well_prepared_qubits_mock):
 
 
 @patch("emu_mps.mps_backend_impl.compute_noise_from_lindbladians")
-@patch("emu_mps.mps_backend_impl.random.random")
-def test_init_lindblad_noise_with_lindbladians(
-    random_mock, compute_noise_from_lindbladians_mock
-):
+def test_init_lindblad_noise_with_lindbladians(compute_noise_from_lindbladians_mock):
     victim = create_noisy_victim()
-    victim.state = MPS.make(QUBIT_COUNT)
     lindbladian1 = torch.tensor([[0, 1], [2, 3j]], dtype=torch.complex128)
     lindbladian2 = torch.tensor([[4j, 5j], [6, 7]], dtype=torch.complex128)
     victim.lindblad_ops = [lindbladian1, lindbladian2]
@@ -195,7 +191,6 @@ def test_init_lindblad_noise_with_lindbladians(
 
     noise_mock = MagicMock()
     compute_noise_from_lindbladians_mock.return_value = noise_mock
-    random_mock.return_value = 0.123
     victim.init_lindblad_noise()
     assert torch.allclose(
         victim.aggregated_lindblad_ops,
@@ -213,6 +208,14 @@ def test_init_lindblad_noise_with_lindbladians(
 
     compute_noise_from_lindbladians_mock.assert_called_with([lindbladian1, lindbladian2])
     assert victim.lindblad_noise is noise_mock
+
+
+@patch("emu_mps.mps_backend_impl.random.random")
+def test_init_jump_threshold(random_mock):
+    victim = create_noisy_victim()
+    victim.state = MPS.make(QUBIT_COUNT)
+    random_mock.return_value = 0.123
+    victim.init_jump_threshold()
     random_mock.assert_called_once()
     assert victim.jump_threshold == 0.123
     assert math.isclose(victim.norm_gap_before_jump, 0.877)

--- a/test/emu_mps/test_mps_backend_impl.py
+++ b/test/emu_mps/test_mps_backend_impl.py
@@ -210,12 +210,12 @@ def test_init_lindblad_noise_with_lindbladians(compute_noise_from_lindbladians_m
     assert victim.lindblad_noise is noise_mock
 
 
-@patch("emu_mps.mps_backend_impl.random.random")
-def test_init_jump_threshold(random_mock):
+@patch("emu_mps.mps_backend_impl.random.uniform")
+def test_set_jump_threshold(random_mock):
     victim = create_noisy_victim()
     victim.state = MPS.make(QUBIT_COUNT)
     random_mock.return_value = 0.123
-    victim.init_jump_threshold()
+    victim.set_jump_threshold(1.0)
     random_mock.assert_called_once()
     assert victim.jump_threshold == 0.123
     assert math.isclose(victim.norm_gap_before_jump, 0.877)


### PR DESCRIPTION
This was detected thanks to an assert regarding baths sizes. Post-jump orthogonalization of the state would apply qr decompositions and change state factor sizes (in the presence of very low precision), without right baths being updated.

Originally an issue posted on Slack:
https://pasqalworkspace.slack.com/archives/C07MUV5K7EU/p1742474264332599

The right baths are not recomputed when root-finding, because the hami ltonian doesn't change between iterations (within one timestep). However, a jump implies applying an operator to the state: the right baths need to be updated.