### PR TITLE
inner and expect of rank 0

### DIFF
--- a/emu_mps/mpo.py
+++ b/emu_mps/mpo.py
@@ -152,7 +152,7 @@ class MPO(Operator[complex, torch.Tensor, MPS]):
                 state.factors[i + 1].device
             )
         acc = new_left_bath(acc, state.factors[n], self.factors[n])
-        return acc.reshape(1).cpu()
+        return acc.reshape(1)[0].cpu()
 
     @classmethod
     def _from_operator_repr(

--- a/emu_mps/mps.py
+++ b/emu_mps/mps.py
@@ -298,7 +298,7 @@ class MPS(State[complex, torch.Tensor]):
             acc = torch.tensordot(acc, other.factors[i].to(acc.device), dims=1)
             acc = torch.tensordot(self.factors[i].conj(), acc, dims=([0, 1], [0, 1]))
 
-        return acc.reshape(1).cpu()
+        return acc.reshape(1)[0].cpu()
 
     def overlap(self, other: State, /) -> torch.Tensor:
         return torch.abs(self.inner(other)) ** 2  # type: ignore[no-any-return]


### PR DESCRIPTION
`MPS.inner` and `MPO.expect` returned a tensor of shape `(1)`, while, since they are actually numerical quantities, it makes more sense for them to return a tensor of shape `()`.