### PR TITLE
fix warning logic

### DIFF
--- a/emu_mps/mps_config.py
+++ b/emu_mps/mps_config.py
@@ -114,11 +114,9 @@ class MPSConfig(EmulationConfig):
                 filemode="w",
                 force=True,
             )
-        if (
-            self.noise_model.runs != 1
-            or self.noise_model.samples_per_run != 1
-            or self.noise_model.runs is not None
-            or self.noise_model.samples_per_run is not None
+        if (self.noise_model.runs != 1 and self.noise_model.runs is not None) or (
+            self.noise_model.samples_per_run != 1
+            and self.noise_model.samples_per_run is not None
         ):
             self.logger.warning(
                 "Warning: The runs and samples_per_run values of the NoiseModel are ignored!"

--- a/emu_sv/sv_config.py
+++ b/emu_sv/sv_config.py
@@ -84,11 +84,9 @@ class SVConfig(EmulationConfig):
                 filemode="w",
                 force=True,
             )
-        if (
-            self.noise_model.runs != 1
-            or self.noise_model.samples_per_run != 1
-            or self.noise_model.runs is not None
-            or self.noise_model.samples_per_run is not None
+        if (self.noise_model.runs != 1 and self.noise_model.runs is not None) or (
+            self.noise_model.samples_per_run != 1
+            and self.noise_model.samples_per_run is not None
         ):
             self.logger.warning(
                 "Warning: The runs and samples_per_run values of the NoiseModel are ignored!"


### PR DESCRIPTION
The logic for throwing the warning about `noise_model` parameters in the config was broken. Fixed it.