### PR TITLE
fix for failing observables after autosave

### DIFF
--- a/ci/emu_mps/pyproject.toml
+++ b/ci/emu_mps/pyproject.toml
@@ -21,7 +21,7 @@ classifiers=[
 ]
 dynamic = ["version"]
 dependencies = [
-  "emu-base==2.0.0"]
+  "emu-base==2.0.1"]
 
 [project.urls]
 Documentation = "https://pasqal-io.github.io/emulators/"

--- a/ci/emu_sv/pyproject.toml
+++ b/ci/emu_sv/pyproject.toml
@@ -21,7 +21,7 @@ classifiers=[
 ]
 dynamic = ["version"]
 dependencies = [
-  "emu-base==2.0.0"]
+  "emu-base==2.0.1"]
 
 [project.urls]
 Documentation = "https://pasqal-io.github.io/emulators/"

--- a/emu_base/__init__.py
+++ b/emu_base/__init__.py
@@ -16,4 +16,4 @@ __all__ = [
     "DEVICE_COUNT",
 ]
 
-__version__ = "2.0.0"
+__version__ = "2.0.1"

--- a/emu_mps/__init__.py
+++ b/emu_mps/__init__.py
@@ -37,4 +37,4 @@ __all__ = [
     "EntanglementEntropy",
 ]
 
-__version__ = "2.0.0"
+__version__ = "2.0.1"

--- a/emu_mps/mps_backend_impl.py
+++ b/emu_mps/mps_backend_impl.py
@@ -151,9 +151,7 @@ class MPSBackendImpl:
     def __getstate__(self) -> dict:
         for obs in self.config.observables:
             obs.apply = MethodType(type(obs).apply, obs)  # type: ignore[method-assign]
-        d = {}
-        for key, val in self.__dict__.items():
-            d[key] = val
+        d = self.__dict__.copy()
         # mypy thinks the method below is an attribute, because of the __getattr__ override
         d["results"] = self.results._to_abstract_repr()  # type: ignore[operator]
         return d

--- a/emu_mps/mps_backend_impl.py
+++ b/emu_mps/mps_backend_impl.py
@@ -151,14 +151,16 @@ class MPSBackendImpl:
     def __getstate__(self) -> dict:
         for obs in self.config.observables:
             obs.apply = MethodType(type(obs).apply, obs)  # type: ignore[method-assign]
-        d = self.__dict__
+        d = {}
+        for key, val in self.__dict__.items():
+            d[key] = val
         # mypy thinks the method below is an attribute, because of the __getattr__ override
         d["results"] = self.results._to_abstract_repr()  # type: ignore[operator]
         return d
 
     def __setstate__(self, d: dict) -> None:
-        d["results"] = Results._from_abstract_repr(d["results"])  # type: ignore [attr-defined]
         self.__dict__ = d
+        self.results = Results._from_abstract_repr(d["results"])  # type: ignore [attr-defined]
         self.config.monkeypatch_observables()
 
     @staticmethod
@@ -444,7 +446,6 @@ class MPSBackendImpl:
         basename = self.autosave_file
         with open(basename.with_suffix(".new"), "wb") as file_handle:
             pickle.dump(self, file_handle)
-
         if basename.is_file():
             os.rename(basename, basename.with_suffix(".bak"))
 

--- a/emu_sv/__init__.py
+++ b/emu_sv/__init__.py
@@ -35,4 +35,4 @@ __all__ = [
     "inner",
 ]
 
-__version__ = "2.0.0"
+__version__ = "2.0.1"


### PR DESCRIPTION
The autosave function modifies the results object in place to a `dict`, which causes observables called after the first autosave to fail since the results are no longer of type `Results`.

The fix is to make sure the `__getstate__` function does not modify the object in place.

I added a test `test_obs_after_autosave` that failed before the test was implemented, and now passes.