### PR TITLE
Sg/do time step as autograd function

### DIFF
--- a/emu_base/math/double_krylov.py
+++ b/emu_base/math/double_krylov.py
@@ -88,7 +88,6 @@ def lanczos(
 
         if n2 < tolerance:
             converged = True
-            print("happy")
             break
 
         lanczos_vectors.append(w / n2)

--- a/emu_base/math/double_krylov.py
+++ b/emu_base/math/double_krylov.py
@@ -88,6 +88,7 @@ def lanczos(
 
         if n2 < tolerance:
             converged = True
+            print("happy")
             break
 
         lanczos_vectors.append(w / n2)

--- a/emu_base/math/double_krylov.py
+++ b/emu_base/math/double_krylov.py
@@ -73,7 +73,9 @@ def lanczos(
     """
     converged = False
     lanczos_vectors = [v / v.norm()]
-    T = torch.zeros(max_krylov_dim + 2, max_krylov_dim + 2, dtype=v.dtype)
+    T = torch.zeros(
+        max_krylov_dim + 2, max_krylov_dim + 2, dtype=v.dtype, device=v.device
+    )
 
     for j in range(max_krylov_dim):
         w = op(lanczos_vectors[-1])

--- a/emu_sv/sv_backend.py
+++ b/emu_sv/sv_backend.py
@@ -9,7 +9,7 @@ from emu_base import PulserData
 
 from emu_sv.state_vector import StateVector
 from emu_sv.sv_config import SVConfig
-from emu_sv.time_evolution import do_time_step
+from emu_sv.time_evolution import EvolveStateVector
 
 
 _TIME_CONVERSION_COEFF = 0.001  # Omega and delta are given in rad/μs, dt in ns
@@ -54,10 +54,10 @@ class SVBackend(EmulatorBackend):
         else:
             state = StateVector.make(nqubits, gpu=self._config.gpu)
 
+        stepper = EvolveStateVector.apply
         for step in range(nsteps):
             dt = self.target_times[step + 1] - self.target_times[step]
-
-            state.vector, H = do_time_step(
+            state.vector, H = stepper(
                 dt * _TIME_CONVERSION_COEFF,
                 omega[step],
                 delta[step],

--- a/emu_sv/time_evolution.py
+++ b/emu_sv/time_evolution.py
@@ -1,7 +1,235 @@
 import torch
-
+from typing import Any
 from emu_base.math.krylov_exp import krylov_exp
+from emu_base.math.double_krylov import double_krylov
 from emu_sv.hamiltonian import RydbergHamiltonian
+
+
+class DHDOmegaSparse:
+    """Implementation of derivative of the Rydberg Hamiltonian respect to Omega
+    following the RydbergHamiltonian sparse format. At the end we are doing,
+    - i dt dH/d𝛺ₖ =− i dt 1/2 𝜎ₓᵏ"""
+
+    def __init__(self, dt: int, index: int, device: str, nqubits: int):
+        self.index = index
+        self.nqubits = nqubits
+        self.dt = dt
+        self.inds = torch.tensor([1, 0], device=device)  # flips the state, for 𝜎ₓ
+
+    def __matmul__(self, vec: torch.Tensor) -> torch.Tensor:
+        vec = vec.reshape((vec.shape[0],) + (2,) * self.nqubits)  # add batch dimension
+        result = torch.zeros(vec.shape, device=vec.device, dtype=vec.dtype)
+        result.index_add_(self.index + 1, self.inds, vec, alpha=-1j * self.dt / 2)
+        return result.reshape(vec.shape[0], -1)
+
+
+class DHDDeltaSparse:
+    """Implementation of derivative of the Rydberg Hamiltonian respect to Omega
+    following the RydbergHamiltonian sparse format. At the end we are doing,
+    - i dt dH/d𝛺ₖ =− i dt 1/2 𝜎ₓᵏ"""
+
+    def __init__(self, dt: int, index: int, device: str, nqubits: int):
+        self.index = index
+        self.nqubits = nqubits
+        diag = torch.zeros((2,) * nqubits, dtype=torch.complex128, device=device)
+        i_fixed = diag.select(index, 1)
+        i_fixed += 1j * dt  # add the delta term for this qubit
+        self.diag = diag.reshape(-1)
+
+    def __matmul__(self, vec: torch.Tensor) -> torch.Tensor:
+        return vec * self.diag
+
+
+class EvolveStateVector(torch.autograd.Function):
+    """Custom autograd implementation of a step in the time evolution."""
+
+    @staticmethod
+    def forward(
+        ctx: Any,
+        dt: float,
+        omegas: torch.Tensor,
+        deltas: torch.Tensor,
+        phis: torch.Tensor,
+        interaction_matrix: torch.Tensor,
+        state: torch.Tensor,
+        krylov_tolerance: float,
+    ) -> tuple[torch.Tensor, RydbergHamiltonian]:
+        """
+        Returns the time evolved state
+            |ψ(t+dt)〉= exp(-i dt H)|ψ(t)〉
+        under the Hamiltonian H built from the input Tensor parameters, omega, delta and
+        the interaction matrix.
+
+        Args:
+            ctx (Any): context object to stash information for backward computation.
+            dt (float): timestep
+            omegas (torch.Tensor): 1D tensor of driving strengths for each qubit.
+            deltas (torch.Tensor): 1D tensor of detuning values for each qubit.
+            phis (torch.Tensor): 1D tensor of phase values for each qubit.
+            interaction_matrix (torch.Tensor): matrix representing the interaction
+                strengths between each pair of qubits.
+            state (Tensor): input state to be evolved
+            krylov_tolerance (float):
+        """
+        ham = RydbergHamiltonian(
+            omegas=omegas,
+            deltas=deltas,
+            phis=phis,
+            interaction_matrix=interaction_matrix,
+            device=state.device,
+        )
+        op = lambda x: -1j * dt * (ham * x)
+        res = krylov_exp(
+            op,
+            state,
+            norm_tolerance=krylov_tolerance,
+            exp_tolerance=krylov_tolerance,
+            is_hermitian=True,
+        )
+        ctx.save_for_backward(omegas, deltas, phis, interaction_matrix, state)
+        ctx.mark_non_differentiable(ham)
+        ctx.dt = dt
+        ctx.tolerance = krylov_tolerance
+        return res, ham
+
+    @staticmethod
+    def backward(ctx: Any, *grad_outputs: tuple[torch.Tensor, Any]) -> tuple[
+        None,
+        torch.Tensor | None,
+        torch.Tensor | None,
+        torch.Tensor | None,
+        None,
+        torch.Tensor | None,
+        None,
+    ]:
+        """
+        In the backward pass we receive a Tensor containing the gradient of the loss L
+        with respect to the output
+            |gψ(t+dt)〉= ∂L/∂|ψ(t+dt)〉,
+        and return the gradients of the loss with respect to the input tensors
+            - gΩⱼ = ∂L/∂Ωⱼ =〈gψ(t+dt)|DU(H,∂H/∂Ωⱼ)|ψ(t)〉
+            - gΔⱼ = ∂L/∂Δⱼ =  ...
+            - |gψ(t)〉= ∂L/∂|ψ(t)〉= exp(i dt H)|gψ(t+dt)〉
+
+        Args:
+            ctx (Any): context object to stash information for backward computation.
+            grad_state_out (torch.Tensor): |gψ(t+dt)〉
+
+        Return:
+            grad_omegas (torch.Tensor): 1D tensor of gradients with respect to Ωⱼ for each qubit.
+            grad_deltas (torch.Tensor): 1D tensor of gradients with respect to Δⱼ for each qubit.
+            grad_state_in (torch.Tensor): 1D tensor gradient with respect to the input state.
+
+        Notes:
+        Gradients are obtained by matching the total variations
+            〈gψ(t+dt)|d|ψ(t+dt)〉= ∑ⱼgΔⱼ*dΔⱼ + ∑ⱼgΩⱼ*dΩⱼ +〈gψ(t)|d|ψ(t)〉  (1)
+
+        For the exponential map U = exp(-i dt H), differentiating reads:
+            d|ψ(t+dt)〉= dU|ψ(t)〉+ Ud|ψ(t)〉
+            dU = ∑ⱼdU(H,∂H/∂Δⱼ) + ∑ⱼdU(H,∂H/∂Ωⱼ)                        (2)
+
+        where dU(H,dH) is the Fréchet derivative of the exponential map
+        along the direction dH
+        - https://eprints.maths.manchester.ac.uk/1218/1/covered/MIMS_ep2008_26.pdf
+        - https://en.wikipedia.org/wiki/Derivative_of_the_exponential_map
+
+        Substituting (2) into (1) leads to the expressions of the gradients
+        with respect to the input tensors above.
+
+        Variations with respect to the Hamiltonian parameters are computed as
+            gΩ = 〈gψ(t+dt)|dU(H,∂H/∂Ω)|ψ(t)〉
+               = Tr( ∂H/∂Ω @ dU(H,|ψ(t)〉〈gψ(t+dt)|) ),
+        where under the trace sign, ∂H/∂Ω and |ψ(t)〉〈gψ(t+dt)| can be switched.
+
+        - The Fréchet derivative is computed in a Arnoldi-Gram-Schmidt
+        decomposition in the `double_krylov` method:
+            dU(H,|a〉〈b|) = V_odd @ ? @ V_even*
+        where V_odd and V_even are orthogonal Krylov basis associated
+        with |a〉 and |b〉respectively.
+
+        - The action of the derivatives of the Hamiltonian with
+        respect to the input parameters are implemented separately in
+            - ∂H/∂Ω: `DHDOmegaSparse`
+            - ∂H/∂Δ: `DHDDeltaSparse`
+
+
+        - dU is the Fréchet derivative
+        F_exp(-i dt H, dH)
+        exp([H dH])  = (exp(H) L(H,dH))
+           ([0  H])    (  0     exp(H))
+
+        For the Hamiltonian parameters
+            gΩ = 〈gψ(t+dt)|L(H,∂H/∂Ω)|ψ(t)〉
+               = Tr( ∂H/∂Ω @ L(H,|ψ(t)〉〈gψ(t+dt)|) )
+
+        L(H,|ψ(t)〉〈gψ(t+dt)|) = VTV^{-1}
+
+        Tr( |0     0| @ exp|dt*H  |ψ(t)〉〈gψ(t+dt)| | )
+          ( |∂H/∂Ω 0|      |  0          dt*H       | )
+
+
+        """
+        grad_state_out = grad_outputs[0][0]
+        omegas, deltas, phis, interaction_matrix, state = ctx.saved_tensors
+        dt = ctx.dt
+        tolerance = 100.0 * ctx.tolerance / abs(dt)
+        ham = RydbergHamiltonian(
+            omegas=omegas,
+            deltas=deltas,
+            phis=phis,
+            interaction_matrix=interaction_matrix,
+            device=state.device,
+        )
+        if ctx.needs_input_grad[1] or ctx.needs_input_grad[2] or ctx.needs_input_grad[3]:
+            op = lambda x: -1j * dt * (ham @ x)
+            lanczos_vectors_even, eT, lanczos_vectors_odd = double_krylov(
+                op, grad_state_out, state, tolerance
+            )
+            even_block = torch.stack(lanczos_vectors_even)
+            odd_block = torch.stack(lanczos_vectors_odd)
+
+            e_l = torch.tensordot(
+                eT[1 : 2 * odd_block.shape[0] : 2, : 2 * even_block.shape[0] : 2].to(
+                    odd_block.device
+                ),
+                odd_block,
+                dims=([0], [0]),
+            )
+            del odd_block
+
+        grad_omegas, grad_deltas, grad_phis, grad_state_in = None, None, None, None
+
+        if ctx.needs_input_grad[1]:
+            grad_omegas = torch.zeros(omegas.shape, dtype=omegas.dtype)
+            for i in range(omegas.shape[-1]):
+                # dh as per the docstring
+                dho = DHDOmegaSparse(dt, i, e_l.device, omegas.shape[-1])
+                # compute the trace
+                v = dho @ e_l
+                grad_omegas[i] = torch.tensordot(
+                    even_block.conj(), v, dims=([0, 1], [0, 1])
+                ).real
+
+        if ctx.needs_input_grad[2]:
+            grad_deltas = torch.zeros(deltas.shape, dtype=deltas.dtype)
+            for i in range(deltas.shape[-1]):
+                # dh as per the docstring
+                dhd = DHDDeltaSparse(dt, i, e_l.device, deltas.shape[-1])
+                # compute the trace
+                v = dhd @ e_l
+                grad_deltas[i] = torch.tensordot(
+                    even_block.conj(), v, dims=([0, 1], [0, 1])
+                ).real
+
+        if ctx.needs_input_grad[3]:
+            grad_phis = torch.zeros(phis.shape, dtype=phis.dtype)
+
+        if ctx.needs_input_grad[5]:
+            op = lambda x: (1j * dt) * (ham @ x)
+            grad_state_in = krylov_exp(op, grad_state_out, tolerance, tolerance)
+
+        # TODO: fix grdient respect tho phases
+        return None, grad_omegas, grad_deltas, grad_phis, None, grad_state_in, None
 
 
 def do_time_step(

--- a/emu_sv/time_evolution.py
+++ b/emu_sv/time_evolution.py
@@ -215,6 +215,11 @@ class EvolveStateVector(torch.autograd.Function):
         tolerance = ctx.tolerance
         nqubits = len(omegas)
 
+        grad_omegas, grad_deltas, grad_phis, grad_state_in = None, None, None, None
+
+        if grad_state_out.norm() < tolerance:
+            return None, None, None, None, None, None, None
+
         ham = RydbergHamiltonian(
             omegas=omegas,
             deltas=deltas,
@@ -234,8 +239,6 @@ class EvolveStateVector(torch.autograd.Function):
             Vg = torch.stack(lanczos_vectors_grad)
             del lanczos_vectors_grad
             e_l = dS.mT @ Vs
-
-        grad_omegas, grad_deltas, grad_phis, grad_state_in = None, None, None, None
 
         if ctx.needs_input_grad[1]:
             grad_omegas = torch.zeros_like(omegas)

--- a/emu_sv/time_evolution.py
+++ b/emu_sv/time_evolution.py
@@ -1,5 +1,5 @@
 import torch
-from typing import Any
+from typing import Any, no_type_check
 from emu_base.math.krylov_exp import krylov_exp
 from emu_base.math.double_krylov import double_krylov
 from emu_sv.hamiltonian import RydbergHamiltonian
@@ -92,13 +92,14 @@ class EvolveStateVector(torch.autograd.Function):
         ctx.tolerance = krylov_tolerance
         return res, ham
 
+    @no_type_check  # mypy complains and I don't know why
     @staticmethod
-    def backward(ctx: Any, *grad_outputs: tuple[torch.Tensor, Any]) -> tuple[
+    def backward(ctx: Any, grad_state_out: torch.Tensor, gham: None) -> tuple[
         None,
         torch.Tensor | None,
         torch.Tensor | None,
         torch.Tensor | None,
-        None,
+        torch.Tensor | None,
         torch.Tensor | None,
         None,
     ]:
@@ -169,7 +170,6 @@ class EvolveStateVector(torch.autograd.Function):
 
 
         """
-        grad_state_out = grad_outputs[0][0]
         omegas, deltas, phis, interaction_matrix, state = ctx.saved_tensors
         dt = ctx.dt
         tolerance = 100.0 * ctx.tolerance / abs(dt)

--- a/emu_sv/time_evolution.py
+++ b/emu_sv/time_evolution.py
@@ -122,7 +122,7 @@ class EvolveStateVector(torch.autograd.Function):
         """
         Returns the time evolved state
             |ψ(t+dt)〉= exp(-i dt H)|ψ(t)〉
-        under the Hamiltonian H built from the input Tensor parameters, omega, delta and
+        under the Hamiltonian H built from the input Tensor parameters, omegas, deltas, phis and
         the interaction matrix.
 
         Args:

--- a/test/emu_sv/test_dense_operator.py
+++ b/test/emu_sv/test_dense_operator.py
@@ -107,10 +107,10 @@ def test_applyto_expect_DenseOperator(zero: str, one: str) -> None:
     )
 
     state = {one + one + one: -1.0, zero + zero + zero: 1.0}
-    from_string = StateVector.from_state_amplitudes(
+    state_from_string = StateVector.from_state_amplitudes(
         eigenstates=(one, zero), amplitudes=state
     )
-    result = operator.apply_to(from_string)  # testing apply_to
+    result = operator.apply_to(state_from_string)  # testing apply_to
 
     state_torch = reduce(torch.kron, [zero_state_torch] * N)
     state_torch -= reduce(torch.kron, [one_state_torch] * N)
@@ -123,6 +123,6 @@ def test_applyto_expect_DenseOperator(zero: str, one: str) -> None:
     assert torch.allclose(mult_state, result.vector.cpu())
 
     # expectation value
-    res = operator.expect(from_string)
+    res = operator.expect(state_from_string)
     expected = state_torch.mH @ mult_state.T
-    assert torch.isclose(torch.tensor(res, dtype=dtype), expected)
+    assert torch.isclose(res, expected)

--- a/test/emu_sv/test_time_evolution.py
+++ b/test/emu_sv/test_time_evolution.py
@@ -2,170 +2,100 @@ import torch
 import pytest
 from test.utils_testing import (
     dense_rydberg_hamiltonian,
-    nn_interaction_matrix,
     randn_interaction_matrix,
 )
 from emu_sv.time_evolution import EvolveStateVector
 
 dtype = torch.complex128
+dtype_params = torch.float64
 device = "cpu"
 
 
+def do_dense_time_step(
+    dt: float,
+    omegas: torch.Tensor,
+    deltas: torch.Tensor,
+    phis: torch.Tensor,
+    interaction_matrix: torch.Tensor,
+    state: torch.Tensor,
+) -> torch.Tensor:
+    H = dense_rydberg_hamiltonian(omegas, deltas, phis, interaction_matrix).to(
+        state.device
+    )
+    return torch.linalg.matrix_exp(-1j * dt * H) @ state
+
+
+def get_randn_ham_params(
+    nqubits: int, with_phase: bool = False, **kwargs
+) -> tuple[torch.Tensor]:
+    omegas = torch.randn(nqubits, **kwargs)
+    deltas = torch.randn(nqubits, **kwargs)
+    if with_phase:
+        phis = torch.randn(nqubits, **kwargs)
+    else:
+        phis = torch.zeros(nqubits)
+    interaction = randn_interaction_matrix(nqubits)
+    return omegas, deltas, phis, interaction
+
+
+def get_randn_state(nqubits: int, **kwargs):
+    state = torch.randn(2**nqubits, **kwargs)
+    return state / state.norm()
+
+
 @pytest.mark.parametrize(
-    ("N", "krylov_tolerance"),
-    [(3, 1e-10), (5, 1e-12), (7, 1e-10), (8, 1e-12)],
+    "N, tolerance, with_phase",
+    [
+        (n, tol, wp)
+        for n in [3, 5, 8]
+        for tol in [1e-8, 1e-10, 1e-12]
+        for wp in [False, True]
+    ],
 )
-def test_forward_no_phase(N: int, krylov_tolerance: float) -> None:
+def test_forward(N: int, tolerance: float, with_phase: bool) -> None:
     torch.manual_seed(1337)
-    omegas = torch.randn(N)
-    deltas = torch.randn(N)
-    phis = torch.zeros_like(omegas)
-    interaction = nn_interaction_matrix(N)
-    ham_params = (omegas, deltas, phis, interaction)
-
-    state = torch.randn(2**N, dtype=dtype, device=device)
-    state /= state.norm()
-
-    H = dense_rydberg_hamiltonian(*ham_params).to(device)
+    ham_params = get_randn_ham_params(N, with_phase=with_phase, dtype=dtype_params)
+    state_in = get_randn_state(N, dtype=dtype, device=device)
     dt = 1.0  # 1 μs big time step
-    ed = torch.linalg.matrix_exp(-1j * dt * H) @ state
-    krylov, _ = EvolveStateVector.apply(
+
+    expected = do_dense_time_step(dt, *ham_params, state_in)
+    state_out, _ = EvolveStateVector.apply(
         dt,
         *ham_params,
-        state,
-        krylov_tolerance,
+        state_in,
+        tolerance,
     )
-    assert torch.allclose(ed, krylov, atol=krylov_tolerance)
+    assert torch.allclose(expected, state_out, atol=tolerance)
 
 
 @pytest.mark.parametrize(
-    ("N", "krylov_tolerance"),
-    [(3, 1e-10), (5, 1e-12), (7, 1e-10), (8, 1e-12)],
+    "N, tolerance",
+    [(n, tol) for n in [3, 5, 8] for tol in [1e-8, 1e-10, 1e-12]],
 )
-def test_forward_with_phase(N: int, krylov_tolerance: float) -> None:
+def test_backward(N, tolerance):
     torch.manual_seed(1337)
-    omegas, deltas, phis = torch.randn(3, N)  # unpack a 3*N tensor
-    interaction = randn_interaction_matrix(N)
-    ham_params = (omegas, deltas, phis, interaction)
-
-    state = torch.randn(2**N, dtype=dtype, device=device)
-    state /= state.norm()
-
-    H = dense_rydberg_hamiltonian(*ham_params).to(device)
-    dt = 1.0  # 1 μs big time step
-    ed = torch.linalg.matrix_exp(-1j * dt * H) @ state
-    krylov, _ = EvolveStateVector.apply(
-        dt,
-        *ham_params,
-        state,
-        krylov_tolerance,
+    ham_params = get_randn_ham_params(
+        N, with_phase=True, dtype=dtype_params, requires_grad=True
     )
-    assert torch.allclose(ed, krylov, atol=krylov_tolerance)
+    state_in = get_randn_state(N, dtype=dtype, device=device, requires_grad=True)
+    dt = 1.0  # big timestep 1 μs
 
-
-dtype_params = torch.float64
-
-
-@pytest.mark.parametrize(
-    "N, krylov_tolerance",
-    [(n, tol) for n in [5, 8] for tol in [1e-8, 1e-10, 1e-12]],
-)
-def test_backward(N, krylov_tolerance):
-    torch.manual_seed(1337)
-    omegas = torch.randn(N, dtype=dtype_params, requires_grad=True)
-    deltas = torch.randn(N, dtype=dtype_params, requires_grad=True)
-    phis = torch.zeros(N, dtype=dtype_params)
-    interactions = randn_interaction_matrix(N)
-
-    ham_params = (omegas, deltas, phis, interactions)
-
-    state = torch.randn(2**N, dtype=dtype, requires_grad=True)
-    state = state / state.norm()
+    # arbitrary vector to construct a scalar
     r = torch.randn(2**N, dtype=dtype)
-    r /= r.norm()
+    r *= torch.randn(1) / r.norm()
 
-    dt = 1.0  # big timestep 1 μs
-
-    krylov, _ = EvolveStateVector.apply(dt, *ham_params, state, krylov_tolerance)
-    scalar = torch.abs(r @ krylov)
-    grads = torch.autograd.grad(scalar, (omegas, deltas, state), retain_graph=True)
-
-    h = dense_rydberg_hamiltonian(*ham_params).to(device)
-    ed = torch.linalg.matrix_exp(-1j * dt * h) @ state
-    ed_scalar = torch.abs(r @ ed)
-    ed_grads = torch.autograd.grad(ed_scalar, (omegas, deltas, state), retain_graph=True)
-
-    # expected tolerance for the gradients is bigger
-    expected_grad_tolerance = krylov_tolerance
-    for grad, ed_grad in zip(grads, ed_grads):
-        assert torch.allclose(grad, ed_grad, rtol=expected_grad_tolerance)
-
-
-@pytest.mark.parametrize(
-    "N, krylov_tolerance",
-    [(n, tol) for n in [3, 7] for tol in [1e-8, 1e-10, 1e-12]],
-)
-def test_backward_Op(N, krylov_tolerance):
-    torch.manual_seed(1337)
-    omegas = torch.randn(N, dtype=dtype_params, requires_grad=True)
-    deltas = torch.randn(N, dtype=dtype_params, requires_grad=True)
-    phis = torch.zeros(N, dtype=dtype_params)
-    interactions = randn_interaction_matrix(N)
-
-    ham_params = (omegas, deltas, phis, interactions)
-
-    state = torch.randn(2**N, dtype=dtype, requires_grad=True)
-    state = state / state.norm()
-
-    dt = 1.0  # big timestep 1 μs
-
-    Op = torch.randn(2**N, 2**N, dtype=dtype)
-    Op /= Op.norm()
-    Op = Op @ Op.mH  # Hermitian observable
-
-    krylov, _ = EvolveStateVector.apply(dt, *ham_params, state, krylov_tolerance)
-    scalar = torch.vdot(krylov, Op @ krylov).real
-    grads = torch.autograd.grad(scalar, (omegas, deltas, state), retain_graph=True)
-
-    h = dense_rydberg_hamiltonian(*ham_params).to(device)
-    ed = torch.linalg.matrix_exp(-1j * dt * h) @ state
-    ed_scalar = torch.vdot(ed, Op @ ed).real
-    ed_grads = torch.autograd.grad(ed_scalar, (omegas, deltas, state), retain_graph=True)
-
-    for grad, ed_grad in zip(grads, ed_grads):
-        assert torch.allclose(grad, ed_grad, rtol=krylov_tolerance)
-
-
-@pytest.mark.parametrize(
-    "N, krylov_tolerance",
-    [(n, tol) for n in [4, 6] for tol in [1e-8, 1e-12]],
-)
-def test_backward_with_phase(N, krylov_tolerance):
-    torch.manual_seed(1337)
-    omegas = torch.randn(N, dtype=dtype_params, requires_grad=True)
-    deltas = torch.randn(N, dtype=dtype_params, requires_grad=True)
-    phis = torch.randn(N, dtype=dtype_params, requires_grad=True)
-    interactions = randn_interaction_matrix(N)
-
-    ham_params = (omegas, deltas, phis, interactions)
-
-    state = torch.randn(2**N, dtype=dtype, requires_grad=True)
-    state = state / state.norm()
-    r = torch.randn(2**N, dtype=dtype)
-    r /= r.norm()
-
-    dt = 1.0  # big timestep 1 μs
-
-    krylov, _ = EvolveStateVector.apply(dt, *ham_params, state, krylov_tolerance)
-    scalar = torch.abs(r @ krylov)
-    grads = torch.autograd.grad(scalar, (omegas, deltas, phis, state), retain_graph=True)
-
-    h = dense_rydberg_hamiltonian(*ham_params).to(device)
-    ed = torch.linalg.matrix_exp(-1j * dt * h) @ state
-    ed_scalar = torch.abs(r @ ed)
-    ed_grads = torch.autograd.grad(
-        ed_scalar, (omegas, deltas, phis, state), retain_graph=True
+    state_out, _ = EvolveStateVector.apply(dt, *ham_params, state_in, tolerance)
+    scalar = torch.vdot(r, state_out).real
+    omegas, deltas, phis = ham_params[0:3]
+    grads = torch.autograd.grad(
+        scalar, (omegas, deltas, phis, state_in), retain_graph=True
     )
 
-    for grad, ed_grad in zip(grads, ed_grads):
-        assert torch.allclose(grad, ed_grad, rtol=krylov_tolerance)
+    expected = do_dense_time_step(dt, *ham_params, state_in)
+    expected_scalar = torch.vdot(r, expected).real
+    expected_grads = torch.autograd.grad(
+        expected_scalar, (omegas, deltas, phis, state_in), retain_graph=True
+    )
+
+    for g, eg in zip(grads, expected_grads):
+        assert torch.allclose(g, eg, rtol=tolerance)

--- a/test/emu_sv/test_time_evolution.py
+++ b/test/emu_sv/test_time_evolution.py
@@ -61,3 +61,83 @@ def test_forward_with_phase(N: int, krylov_tolerance: float) -> None:
         krylov_tolerance,
     )
     assert torch.allclose(ed, krylov, atol=krylov_tolerance)
+
+
+dtype_params = torch.float64
+
+
+@pytest.mark.parametrize(
+    "N, krylov_tolerance",
+    [(n, tol) for n in [5, 8] for tol in [1e-8, 1e-10, 1e-12]],
+)
+def test_backward(N, krylov_tolerance):
+    torch.manual_seed(1337)
+    omegas = torch.randn(N, dtype=dtype_params, requires_grad=True)
+    deltas = torch.randn(N, dtype=dtype_params, requires_grad=True)
+    phis = torch.zeros(N, dtype=dtype_params)
+    interactions = torch.zeros(N, N, dtype=dtype_params)
+    for i in range(N - 1):
+        interactions[i, i + 1] = 1
+        interactions[i + 1, i] = 1
+
+    ham_params = (omegas, deltas, phis, interactions)
+
+    state = torch.randn(2**N, dtype=dtype, requires_grad=True)
+    state = state / state.norm()
+    r = torch.randn(2**N, dtype=dtype)
+    r /= r.norm()
+
+    dt = 1.0  # big timestep 1 μs
+
+    krylov, _ = EvolveStateVector.apply(dt, *ham_params, state, krylov_tolerance)
+    scalar = torch.abs(r @ krylov)
+    grads = torch.autograd.grad(scalar, (omegas, deltas, state), retain_graph=True)
+
+    h = dense_rydberg_hamiltonian(*ham_params).to(device)
+    ed = torch.linalg.matrix_exp(-1j * dt * h) @ state
+    ed_scalar = torch.abs(r @ ed)
+    ed_grads = torch.autograd.grad(ed_scalar, (omegas, deltas, state), retain_graph=True)
+
+    # expected tolerance for the gradients is bigger
+    expected_grad_tolerance = 100 * krylov_tolerance / abs(dt)
+    for grad, ed_grad in zip(grads, ed_grads):
+        assert torch.allclose(grad, ed_grad, atol=expected_grad_tolerance)
+
+
+@pytest.mark.parametrize(
+    "N, krylov_tolerance",
+    [(n, tol) for n in [3, 7] for tol in [1e-8, 1e-10, 1e-12]],
+)
+def test_backward_Op(N, krylov_tolerance):
+    torch.manual_seed(1337)
+    omegas = torch.randn(N, dtype=dtype_params, requires_grad=True)
+    deltas = torch.randn(N, dtype=dtype_params, requires_grad=True)
+    phis = torch.zeros(N, dtype=dtype_params)
+    interactions = torch.zeros(N, N, dtype=dtype_params)
+    for i in range(N):
+        for j in range(i + 1, N):
+            interactions[i, j] = 1 / abs(j - i)
+
+    ham_params = (omegas, deltas, phis, interactions)
+
+    state = torch.randn(2**N, dtype=dtype, requires_grad=True)
+    state = state / state.norm()
+
+    dt = 1.0  # big timestep 1 μs
+
+    Op = torch.randn(2**N, 2**N, dtype=dtype)
+    Op += Op.mH  # Hermitian observable
+
+    krylov, _ = EvolveStateVector.apply(dt, *ham_params, state, krylov_tolerance)
+    scalar = torch.vdot(krylov, Op @ krylov).real
+    grads = torch.autograd.grad(scalar, (omegas, deltas, state), retain_graph=True)
+
+    h = dense_rydberg_hamiltonian(*ham_params).to(device)
+    ed = torch.linalg.matrix_exp(-1j * dt * h) @ state
+    ed_scalar = torch.vdot(ed, Op @ ed).real
+    ed_grads = torch.autograd.grad(ed_scalar, (omegas, deltas, state), retain_graph=True)
+
+    # expected tolerance for the gradients is bigger
+    expected_grad_tolerance = 100 * krylov_tolerance / abs(dt)
+    for grad, ed_grad in zip(grads, ed_grads):
+        assert torch.allclose(grad, ed_grad, atol=expected_grad_tolerance)

--- a/test/emu_sv/test_time_evolution.py
+++ b/test/emu_sv/test_time_evolution.py
@@ -38,7 +38,7 @@ def get_randn_ham_params(
     return omegas, deltas, phis, interaction
 
 
-def get_randn_state(nqubits: int, **kwargs):
+def get_randn_state(nqubits: int, **kwargs) -> torch.Tensor:
     state = torch.randn(2**nqubits, **kwargs)
     return state / state.norm()
 

--- a/test/emu_sv/test_time_evolution.py
+++ b/test/emu_sv/test_time_evolution.py
@@ -5,7 +5,7 @@ from test.utils_testing import (
     nn_interaction_matrix,
     randn_interaction_matrix,
 )
-from emu_sv.time_evolution import do_time_step
+from emu_sv.time_evolution import EvolveStateVector
 
 dtype = torch.complex128
 device = "cpu"
@@ -29,7 +29,7 @@ def test_forward_no_phase(N: int, krylov_tolerance: float) -> None:
     H = dense_rydberg_hamiltonian(*ham_params).to(device)
     dt = 1.0  # 1 μs big time step
     ed = torch.linalg.matrix_exp(-1j * dt * H) @ state
-    krylov, _ = do_time_step(
+    krylov, _ = EvolveStateVector.apply(
         dt,
         *ham_params,
         state,
@@ -54,7 +54,7 @@ def test_forward_with_phase(N: int, krylov_tolerance: float) -> None:
     H = dense_rydberg_hamiltonian(*ham_params).to(device)
     dt = 1.0  # 1 μs big time step
     ed = torch.linalg.matrix_exp(-1j * dt * H) @ state
-    krylov, _ = do_time_step(
+    krylov, _ = EvolveStateVector.apply(
         dt,
         *ham_params,
         state,

--- a/test/emu_sv/test_time_evolution.py
+++ b/test/emu_sv/test_time_evolution.py
@@ -81,8 +81,8 @@ def test_backward(N, tolerance):
     dt = 1.0  # big timestep 1 μs
 
     # arbitrary vector to construct a scalar
-    r = torch.randn(2**N, dtype=dtype)
-    r *= torch.randn(1) / r.norm()
+    r = torch.randn(2**N, dtype=dtype, device=device)
+    r *= 0.71 / r.norm()
 
     state_out, _ = EvolveStateVector.apply(dt, *ham_params, state_in, tolerance)
     scalar = torch.vdot(r, state_out).real


### PR DESCRIPTION
Support gradient backpropagation for time steps where $\Omega$, $\Delta$ or $\Phi$ require it.

### Changes
- `do_time_step` is now a `torch.autograd.Function`
    - forward simply do a krylov time step as before
    - backward propagate the gradient of the output state to the input (as prescribed in [torch docs](https://pytorch.org/tutorials/beginner/examples_autograd/two_layer_net_custom_function.html))
- `backward` is tested against dense linear algebra, results within imposed relative tolerance

### Benchmark
 [new run](https://gitlab.pasqal.com/emulation/rydberg-atoms/benchmarks_github_gitlab/-/jobs/1467498/artifacts/file/benchmarks/emu_sv_cpu_gpu/results/emu_sv_runtimes.png) vs [old run](https://gitlab.pasqal.com/emulation/rydberg-atoms/benchmarks_github_gitlab/-/jobs/1463051/artifacts/file/benchmarks/emu_sv_cpu_gpu/results/emu_sv_runtimes.png) of the `emu_sv_cpu_gpu` benchmark show same runtime and memory consumption in the logs below.

For 20 qubits - GPU
new
```
step = 448/450, RSS = 260.182 MB, Δt = 0.014 s
step = 449/450, RSS = 260.182 MB, Δt = 0.014 s
step = 450/450, RSS = 260.182 MB, Δt = 0.077 s
```
old
```
step = 448/450, RSS = 260.182 MB, Δt = 0.014 s
step = 449/450, RSS = 260.182 MB, Δt = 0.014 s
step = 450/450, RSS = 260.182 MB, Δt = 0.074 s
```

For 20 qubits - CPU
new
```
step = 448/450, RSS = 1326.564 MB, Δt = 0.189 s
step = 449/450, RSS = 1326.564 MB, Δt = 0.157 s
step = 450/450, RSS = 1326.564 MB, Δt = 0.191 s
```
old
```
step = 448/450, RSS = 1300.072 MB, Δt = 0.195 s
step = 449/450, RSS = 1300.072 MB, Δt = 0.201 s
step = 450/450, RSS = 1300.072 MB, Δt = 0.211 s
```

### Minor changes
- small fix in `test_dense_operator.py ` to get rid of a warning in tests

### Disscusion
- testing also with `gradcheck`
I propose I open a separate issue for it