### PR TITLE
fix memory issue in emu-sv

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -27,4 +27,4 @@ repos:
     hooks:
       - id: mypy
         exclude: examples|test|ci
-        additional_dependencies: [torch==2.5.0, "pulser-core==1.4.*"]  # The version in pyproject.toml must match
+        additional_dependencies: [torch==2.7.0, "pulser-core==1.4.*"]  # The version in pyproject.toml must match

--- a/ci/emu_base/pyproject.toml
+++ b/ci/emu_base/pyproject.toml
@@ -21,7 +21,7 @@ classifiers=[
 ]
 dependencies = [
   "pulser-core==1.4.*",
-  "torch==2.5.0"]
+  "torch==2.7.0"]
 dynamic = ["version"]
 
 [project.urls]

--- a/ci/emu_mps/pyproject.toml
+++ b/ci/emu_mps/pyproject.toml
@@ -21,7 +21,7 @@ classifiers=[
 ]
 dynamic = ["version"]
 dependencies = [
-  "emu-base==2.0.1"]
+  "emu-base==2.0.2"]
 
 [project.urls]
 Documentation = "https://pasqal-io.github.io/emulators/"

--- a/ci/emu_sv/pyproject.toml
+++ b/ci/emu_sv/pyproject.toml
@@ -21,7 +21,7 @@ classifiers=[
 ]
 dynamic = ["version"]
 dependencies = [
-  "emu-base==2.0.1"]
+  "emu-base==2.0.2"]
 
 [project.urls]
 Documentation = "https://pasqal-io.github.io/emulators/"

--- a/emu_base/__init__.py
+++ b/emu_base/__init__.py
@@ -16,4 +16,4 @@ __all__ = [
     "DEVICE_COUNT",
 ]
 
-__version__ = "2.0.1"
+__version__ = "2.0.2"

--- a/emu_mps/__init__.py
+++ b/emu_mps/__init__.py
@@ -37,4 +37,4 @@ __all__ = [
     "EntanglementEntropy",
 ]
 
-__version__ = "2.0.1"
+__version__ = "2.0.2"

--- a/emu_mps/mps_backend_impl.py
+++ b/emu_mps/mps_backend_impl.py
@@ -538,7 +538,7 @@ class NoisyMPSBackendImpl(MPSBackendImpl):
 
     def set_jump_threshold(self, bound: float) -> None:
         self.jump_threshold = random.uniform(0.0, bound)
-        self.norm_gap_before_jump = self.state.norm() ** 2 - self.jump_threshold
+        self.norm_gap_before_jump = self.state.norm().item() ** 2 - self.jump_threshold
 
     def init(self) -> None:
         self.init_lindblad_noise()
@@ -549,7 +549,7 @@ class NoisyMPSBackendImpl(MPSBackendImpl):
         previous_time = self.current_time
         self.current_time = self.target_time
         previous_norm_gap_before_jump = self.norm_gap_before_jump
-        self.norm_gap_before_jump = self.state.norm() ** 2 - self.jump_threshold
+        self.norm_gap_before_jump = self.state.norm().item() ** 2 - self.jump_threshold
 
         if self.root_finder is None:
             # No quantum jump location finding in progress
@@ -569,7 +569,7 @@ class NoisyMPSBackendImpl(MPSBackendImpl):
 
             return
 
-        self.norm_gap_before_jump = self.state.norm() ** 2 - self.jump_threshold
+        self.norm_gap_before_jump = self.state.norm().item() ** 2 - self.jump_threshold
         self.root_finder.provide_ordinate(self.current_time, self.norm_gap_before_jump)
 
         if self.root_finder.is_converged(tolerance=1):
@@ -595,7 +595,7 @@ class NoisyMPSBackendImpl(MPSBackendImpl):
         self.state *= 1 / self.state.norm()
         self.init_baths()
 
-        norm_after_normalizing = self.state.norm()
+        norm_after_normalizing = self.state.norm().item()
         assert math.isclose(norm_after_normalizing, 1, abs_tol=1e-10)
         self.set_jump_threshold(norm_after_normalizing**2)
 

--- a/emu_sv/__init__.py
+++ b/emu_sv/__init__.py
@@ -35,4 +35,4 @@ __all__ = [
     "inner",
 ]
 
-__version__ = "2.0.1"
+__version__ = "2.0.2"

--- a/emu_sv/hamiltonian.py
+++ b/emu_sv/hamiltonian.py
@@ -50,10 +50,7 @@ class RydbergHamiltonian:
 
         self.diag: torch.Tensor = self._create_diagonal()
         self.inds = torch.tensor([1, 0], device=self.device)  # flips the state, for σˣ
-
-        self._apply_sigma_operators = self._apply_sigma_operators_real
-        if self.phis.any():
-            self._apply_sigma_operators = self._apply_sigma_operators_complex
+        self.complex = self.phis.any()
 
     def __mul__(self, vec: torch.Tensor) -> torch.Tensor:
         """
@@ -73,7 +70,10 @@ class RydbergHamiltonian:
         # (-∑ⱼΔⱼnⱼ + ∑ᵢ﹥ⱼUᵢⱼnᵢnⱼ)|ψ❭
         result = self.diag * vec
         # ∑ⱼΩⱼ/2[cos(ϕⱼ)σˣⱼ + sin(ϕⱼ)σʸⱼ]|ψ❭
-        self._apply_sigma_operators(result, vec)
+        if self.complex:
+            self._apply_sigma_operators_complex(result, vec)
+        else:
+            self._apply_sigma_operators_real(result, vec)
         return result
 
     def _apply_sigma_operators_real(

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,7 +21,7 @@ classifiers=[
 ]
 dependencies = [
   "pulser-core==1.4.*",
-  "torch==2.5.0"]  # The version in .pre-commit-config.yaml must match
+  "torch==2.7.0"]  # The version in .pre-commit-config.yaml must match
 dynamic = ["version"]
 
 [tool.setuptools]

--- a/test/emu_sv/test_hamiltonian.py
+++ b/test/emu_sv/test_hamiltonian.py
@@ -103,7 +103,7 @@ def test_call_sigma_real_complex() -> None:
         )
         ham_w_phase * state.vector
         assert ham_w_phase.complex
-        assert ham_w_phase._apply_sigma_operators_complex.called_once()
+        ham_w_phase._apply_sigma_operators_complex.assert_called_once()
 
     with patch.object(
         RydbergHamiltonian,
@@ -119,4 +119,4 @@ def test_call_sigma_real_complex() -> None:
         )
         ham_zero_phase * state.vector
         assert not ham_zero_phase.complex
-        assert ham_zero_phase._apply_sigma_operators_real.called_once()
+        ham_zero_phase._apply_sigma_operators_real.assert_called_once()


### PR DESCRIPTION
`RydbergHamiltonian` created a circular reference to itself (I don't understand why this would be the case, but the evidence points to it), causing mainly the `diag` tensor to linger in memory.