### PR TITLE
Reduce peak memory usage in emu-mps

### DIFF
--- a/emu_base/math/krylov_exp.py
+++ b/emu_base/math/krylov_exp.py
@@ -67,7 +67,8 @@ def krylov_exp_impl(
                 result=result, converged=True, happy_breakdown=True, iteration_count=j + 1
             )
 
-        lanczos_vectors.append(w / n2)
+        w = w / n2
+        lanczos_vectors.append(w)
 
         # Compute exponential of extended T matrix
         T[j + 2, j + 1] = 1

--- a/emu_mps/tdvp.py
+++ b/emu_mps/tdvp.py
@@ -73,8 +73,16 @@ def apply_effective_Hamiltonian(
     # this order seems to be pretty balanced, but needs to be
     # revisited when use-cases are more well-known
     state = torch.tensordot(left_bath, state, 1)
-    state = torch.tensordot(state, ham, ([1, 2], [0, 2]))
-    state = torch.tensordot(state, right_bath, ([3, 1], [1, 2]))
+    state = state.permute(0, 3, 1, 2)
+    ham = ham.permute(0, 2, 1, 3)
+    state = state.reshape(state.shape[0], state.shape[1], -1).contiguous()
+    ham = ham.reshape(-1, ham.shape[2], ham.shape[3]).contiguous()
+    state = torch.tensordot(state, ham, 1)
+    state = state.permute(0, 2, 1, 3)
+    state = state.reshape(state.shape[0], state.shape[1], -1).contiguous()
+    right_bath = right_bath.permute(2, 1, 0)
+    right_bath = right_bath.reshape(-1, right_bath.shape[2]).contiguous()
+    state = torch.tensordot(state, right_bath, 1)
     return state
 
 


### PR DESCRIPTION
Using the PyTorch memory profiler I discovered some stuff, notably
that there were hidden copies of tensors made in `apply_effective_hamiltonian` due to tensordot on multiple dimensions requiring specific tensor setup


This change seems to reduce peak memory usage of simulation by a good 15% depending on settings (the memory gain is in apply_effective_hamiltonian)


Running a afm sequence with 5*6 qubit grid on gpu cluster
Before:
```
# (venv) [plehenaff@node07 emu-ct]$ time python3 random_shit/pickle_result.py
# step = 1/104, χ = 2, |ψ| = 0.003 MB, RSS = 9.375 MB, Δt = 1.237 s
# step = 2/104, χ = 2, |ψ| = 0.003 MB, RSS = 9.378 MB, Δt = 0.704 s
# step = 3/104, χ = 2, |ψ| = 0.003 MB, RSS = 9.378 MB, Δt = 0.672 s
# step = 4/104, χ = 2, |ψ| = 0.003 MB, RSS = 9.378 MB, Δt = 0.687 s
# step = 5/104, χ = 2, |ψ| = 0.003 MB, RSS = 9.378 MB, Δt = 0.710 s
# step = 6/104, χ = 2, |ψ| = 0.003 MB, RSS = 9.378 MB, Δt = 0.708 s
# step = 7/104, χ = 2, |ψ| = 0.003 MB, RSS = 9.378 MB, Δt = 0.722 s
# step = 8/104, χ = 5, |ψ| = 0.011 MB, RSS = 9.410 MB, Δt = 0.848 s
# step = 9/104, χ = 9, |ψ| = 0.041 MB, RSS = 9.547 MB, Δt = 1.033 s
# step = 10/104, χ = 24, |ψ| = 0.211 MB, RSS = 11.093 MB, Δt = 1.234 s
# step = 11/104, χ = 37, |ψ| = 0.518 MB, RSS = 15.805 MB, Δt = 1.376 s
# step = 12/104, χ = 44, |ψ| = 0.752 MB, RSS = 19.847 MB, Δt = 1.396 s
# step = 13/104, χ = 48, |ψ| = 0.888 MB, RSS = 23.206 MB, Δt = 1.421 s
# step = 14/104, χ = 49, |ψ| = 0.942 MB, RSS = 25.557 MB, Δt = 1.421 s
# step = 15/104, χ = 51, |ψ| = 1.010 MB, RSS = 26.335 MB, Δt = 1.444 s
# step = 16/104, χ = 53, |ψ| = 1.071 MB, RSS = 27.558 MB, Δt = 1.447 s
# step = 17/104, χ = 55, |ψ| = 1.127 MB, RSS = 29.071 MB, Δt = 1.448 s
# step = 18/104, χ = 56, |ψ| = 1.166 MB, RSS = 30.163 MB, Δt = 1.446 s
# step = 19/104, χ = 57, |ψ| = 1.200 MB, RSS = 30.895 MB, Δt = 1.417 s
# step = 20/104, χ = 58, |ψ| = 1.241 MB, RSS = 31.823 MB, Δt = 1.419 s
# step = 21/104, χ = 59, |ψ| = 1.260 MB, RSS = 32.446 MB, Δt = 1.398 s
# step = 22/104, χ = 61, |ψ| = 1.324 MB, RSS = 33.456 MB, Δt = 1.404 s
# step = 23/104, χ = 61, |ψ| = 1.336 MB, RSS = 35.280 MB, Δt = 1.400 s
# step = 24/104, χ = 62, |ψ| = 1.364 MB, RSS = 35.280 MB, Δt = 1.373 s
# step = 25/104, χ = 63, |ψ| = 1.411 MB, RSS = 35.712 MB, Δt = 1.356 s
# step = 26/104, χ = 63, |ψ| = 1.425 MB, RSS = 36.946 MB, Δt = 1.351 s
# step = 27/104, χ = 64, |ψ| = 1.492 MB, RSS = 37.382 MB, Δt = 1.337 s
# step = 28/104, χ = 66, |ψ| = 1.551 MB, RSS = 39.407 MB, Δt = 1.315 s
# step = 29/104, χ = 67, |ψ| = 1.608 MB, RSS = 40.038 MB, Δt = 1.314 s
# step = 30/104, χ = 69, |ψ| = 1.690 MB, RSS = 41.882 MB, Δt = 1.303 s
# step = 31/104, χ = 71, |ψ| = 1.786 MB, RSS = 43.372 MB, Δt = 1.292 s
# step = 32/104, χ = 74, |ψ| = 1.905 MB, RSS = 44.961 MB, Δt = 1.291 s
# step = 33/104, χ = 78, |ψ| = 2.115 MB, RSS = 48.350 MB, Δt = 1.293 s
# step = 34/104, χ = 83, |ψ| = 2.379 MB, RSS = 54.518 MB, Δt = 1.294 s
# step = 35/104, χ = 88, |ψ| = 2.584 MB, RSS = 58.887 MB, Δt = 1.264 s
# step = 36/104, χ = 94, |ψ| = 2.993 MB, RSS = 63.022 MB, Δt = 1.280 s
# step = 37/104, χ = 101, |ψ| = 3.397 MB, RSS = 70.726 MB, Δt = 1.284 s
# step = 38/104, χ = 107, |ψ| = 3.835 MB, RSS = 81.202 MB, Δt = 1.290 s
# step = 39/104, χ = 112, |ψ| = 4.184 MB, RSS = 87.291 MB, Δt = 1.284 s
# step = 40/104, χ = 119, |ψ| = 4.694 MB, RSS = 94.084 MB, Δt = 1.292 s
# step = 41/104, χ = 124, |ψ| = 5.158 MB, RSS = 103.646 MB, Δt = 1.311 s
# step = 42/104, χ = 130, |ψ| = 5.645 MB, RSS = 111.085 MB, Δt = 1.347 s
# step = 43/104, χ = 136, |ψ| = 6.147 MB, RSS = 123.675 MB, Δt = 1.297 s
# step = 44/104, χ = 143, |ψ| = 6.708 MB, RSS = 135.674 MB, Δt = 1.257 s
# step = 45/104, χ = 152, |ψ| = 7.444 MB, RSS = 146.290 MB, Δt = 1.312 s
# step = 46/104, χ = 162, |ψ| = 8.319 MB, RSS = 163.402 MB, Δt = 1.319 s
# step = 47/104, χ = 174, |ψ| = 9.526 MB, RSS = 185.082 MB, Δt = 1.298 s
# step = 48/104, χ = 190, |ψ| = 11.085 MB, RSS = 211.632 MB, Δt = 1.332 s
# step = 49/104, χ = 207, |ψ| = 13.004 MB, RSS = 250.026 MB, Δt = 1.363 s
# step = 50/104, χ = 224, |ψ| = 15.087 MB, RSS = 293.057 MB, Δt = 1.449 s
# step = 51/104, χ = 243, |ψ| = 17.424 MB, RSS = 335.199 MB, Δt = 1.509 s
# step = 52/104, χ = 263, |ψ| = 19.896 MB, RSS = 386.383 MB, Δt = 1.608 s
# step = 53/104, χ = 284, |ψ| = 22.781 MB, RSS = 443.998 MB, Δt = 1.664 s
# step = 54/104, χ = 307, |ψ| = 25.967 MB, RSS = 517.043 MB, Δt = 1.748 s
# step = 55/104, χ = 331, |ψ| = 29.627 MB, RSS = 594.238 MB, Δt = 1.852 s
# step = 56/104, χ = 356, |ψ| = 33.797 MB, RSS = 670.135 MB, Δt = 1.971 s
# step = 57/104, χ = 385, |ψ| = 38.745 MB, RSS = 772.838 MB, Δt = 2.116 s
# step = 58/104, χ = 416, |ψ| = 45.002 MB, RSS = 898.362 MB, Δt = 2.363 s
# step = 59/104, χ = 450, |ψ| = 51.866 MB, RSS = 1048.202 MB, Δt = 2.587 s
# step = 60/104, χ = 486, |ψ| = 59.285 MB, RSS = 1210.544 MB, Δt = 2.824 s
# step = 61/104, χ = 520, |ψ| = 66.863 MB, RSS = 1395.905 MB, Δt = 3.134 s
# step = 62/104, χ = 554, |ψ| = 74.760 MB, RSS = 1580.828 MB, Δt = 3.478 s
# step = 63/104, χ = 589, |ψ| = 83.229 MB, RSS = 1776.996 MB, Δt = 3.871 s
# step = 64/104, χ = 624, |ψ| = 92.107 MB, RSS = 1989.711 MB, Δt = 4.273 s
# step = 65/104, χ = 659, |ψ| = 101.209 MB, RSS = 2223.182 MB, Δt = 4.729 s
# step = 66/104, χ = 691, |ψ| = 109.576 MB, RSS = 2453.314 MB, Δt = 5.223 s
# step = 67/104, χ = 719, |ψ| = 117.165 MB, RSS = 2665.334 MB, Δt = 5.600 s
# step = 68/104, χ = 744, |ψ| = 124.377 MB, RSS = 2862.854 MB, Δt = 6.022 s
# step = 69/104, χ = 767, |ψ| = 130.824 MB, RSS = 3046.531 MB, Δt = 6.539 s
# step = 70/104, χ = 787, |ψ| = 136.876 MB, RSS = 3219.238 MB, Δt = 6.853 s
# step = 71/104, χ = 806, |ψ| = 142.393 MB, RSS = 3373.808 MB, Δt = 7.221 s
# step = 72/104, χ = 827, |ψ| = 148.775 MB, RSS = 3532.866 MB, Δt = 7.551 s
# step = 73/104, χ = 851, |ψ| = 156.350 MB, RSS = 3668.868 MB, Δt = 7.693 s
# step = 74/104, χ = 876, |ψ| = 165.217 MB, RSS = 3876.424 MB, Δt = 8.047 s
# step = 75/104, χ = 902, |ψ| = 174.382 MB, RSS = 4103.055 MB, Δt = 8.669 s
# step = 76/104, χ = 930, |ψ| = 184.150 MB, RSS = 4337.099 MB, Δt = 9.231 s
# step = 77/104, χ = 956, |ψ| = 193.629 MB, RSS = 4578.188 MB, Δt = 9.787 s
# step = 78/104, χ = 982, |ψ| = 202.730 MB, RSS = 4825.961 MB, Δt = 10.406 s
# step = 79/104, χ = 1006, |ψ| = 211.105 MB, RSS = 5055.897 MB, Δt = 11.030 s
# step = 80/104, χ = 1024, |ψ| = 219.221 MB, RSS = 5285.052 MB, Δt = 11.696 s
# step = 81/104, χ = 1024, |ψ| = 226.982 MB, RSS = 5498.858 MB, Δt = 12.091 s
# step = 82/104, χ = 1024, |ψ| = 234.603 MB, RSS = 5709.302 MB, Δt = 12.586 s
# step = 83/104, χ = 1024, |ψ| = 240.484 MB, RSS = 5851.398 MB, Δt = 12.950 s
# step = 84/104, χ = 1024, |ψ| = 247.018 MB, RSS = 5905.676 MB, Δt = 12.930 s
# step = 85/104, χ = 1024, |ψ| = 254.882 MB, RSS = 5905.676 MB, Δt = 12.607 s
# step = 86/104, χ = 1024, |ψ| = 263.284 MB, RSS = 5976.556 MB, Δt = 13.030 s
# step = 87/104, χ = 1024, |ψ| = 268.815 MB, RSS = 6115.841 MB, Δt = 13.271 s
# step = 88/104, χ = 1024, |ψ| = 274.200 MB, RSS = 6175.488 MB, Δt = 13.591 s
# step = 89/104, χ = 1024, |ψ| = 280.042 MB, RSS = 6222.992 MB, Δt = 13.889 s
# step = 90/104, χ = 1024, |ψ| = 286.259 MB, RSS = 6274.641 MB, Δt = 14.202 s
# step = 91/104, χ = 1024, |ψ| = 293.416 MB, RSS = 6331.980 MB, Δt = 14.535 s
# step = 92/104, χ = 1024, |ψ| = 300.781 MB, RSS = 6395.626 MB, Δt = 14.933 s
# step = 93/104, χ = 1024, |ψ| = 306.802 MB, RSS = 6465.266 MB, Δt = 15.303 s
# step = 94/104, χ = 1024, |ψ| = 310.251 MB, RSS = 6507.930 MB, Δt = 15.492 s
# step = 95/104, χ = 1024, |ψ| = 313.482 MB, RSS = 6534.900 MB, Δt = 15.638 s
# step = 96/104, χ = 1024, |ψ| = 316.372 MB, RSS = 6561.818 MB, Δt = 15.789 s
# step = 97/104, χ = 1024, |ψ| = 318.667 MB, RSS = 6585.276 MB, Δt = 15.924 s
# step = 98/104, χ = 1024, |ψ| = 320.453 MB, RSS = 6669.708 MB, Δt = 16.698 s
# step = 99/104, χ = 1024, |ψ| = 321.469 MB, RSS = 6686.228 MB, Δt = 17.717 s
# step = 100/104, χ = 1024, |ψ| = 321.722 MB, RSS = 6694.074 MB, Δt = 17.809 s
# step = 101/104, χ = 1024, |ψ| = 321.722 MB, RSS = 6694.223 MB, Δt = 17.815 s
# step = 102/104, χ = 1024, |ψ| = 321.616 MB, RSS = 6694.223 MB, Δt = 17.840 s
# step = 103/104, χ = 1024, |ψ| = 321.563 MB, RSS = 6694.223 MB, Δt = 17.826 s
# step = 104/104, χ = 1024, |ψ| = 319.744 MB, RSS = 6694.223 MB, Δt = 12.797 s
#
# real	9m46.045s
# user	9m42.731s
# sys	0m4.845s

```


After:
```
# (venv) [plehenaff@node07 emu-ct]$ time python3 random_shit/pickle_result.py
# step = 1/104, χ = 2, |ψ| = 0.003 MB, RSS = 9.375 MB, Δt = 1.227 s
# step = 2/104, χ = 2, |ψ| = 0.003 MB, RSS = 9.378 MB, Δt = 0.735 s
# step = 3/104, χ = 2, |ψ| = 0.003 MB, RSS = 9.378 MB, Δt = 0.703 s
# step = 4/104, χ = 2, |ψ| = 0.003 MB, RSS = 9.378 MB, Δt = 0.717 s
# step = 5/104, χ = 2, |ψ| = 0.003 MB, RSS = 9.378 MB, Δt = 0.743 s
# step = 6/104, χ = 2, |ψ| = 0.003 MB, RSS = 9.378 MB, Δt = 0.739 s
# step = 7/104, χ = 2, |ψ| = 0.003 MB, RSS = 9.378 MB, Δt = 0.758 s
# step = 8/104, χ = 5, |ψ| = 0.011 MB, RSS = 9.410 MB, Δt = 0.886 s
# step = 9/104, χ = 9, |ψ| = 0.041 MB, RSS = 9.547 MB, Δt = 1.069 s
# step = 10/104, χ = 24, |ψ| = 0.211 MB, RSS = 10.786 MB, Δt = 1.294 s
# step = 11/104, χ = 37, |ψ| = 0.518 MB, RSS = 14.662 MB, Δt = 1.434 s
# step = 12/104, χ = 44, |ψ| = 0.747 MB, RSS = 18.100 MB, Δt = 1.466 s
# step = 13/104, χ = 48, |ψ| = 0.891 MB, RSS = 21.154 MB, Δt = 1.493 s
# step = 14/104, χ = 49, |ψ| = 0.936 MB, RSS = 23.006 MB, Δt = 1.491 s
# step = 15/104, χ = 51, |ψ| = 1.013 MB, RSS = 23.817 MB, Δt = 1.515 s
# step = 16/104, χ = 53, |ψ| = 1.069 MB, RSS = 25.222 MB, Δt = 1.522 s
# step = 17/104, χ = 55, |ψ| = 1.125 MB, RSS = 26.109 MB, Δt = 1.521 s
# step = 18/104, χ = 56, |ψ| = 1.159 MB, RSS = 27.301 MB, Δt = 1.524 s
# step = 19/104, χ = 57, |ψ| = 1.190 MB, RSS = 27.643 MB, Δt = 1.484 s
# step = 20/104, χ = 58, |ψ| = 1.231 MB, RSS = 28.179 MB, Δt = 1.506 s
# step = 21/104, χ = 59, |ψ| = 1.258 MB, RSS = 28.884 MB, Δt = 1.488 s
# step = 22/104, χ = 61, |ψ| = 1.327 MB, RSS = 29.604 MB, Δt = 1.474 s
# step = 23/104, χ = 61, |ψ| = 1.337 MB, RSS = 30.530 MB, Δt = 1.465 s
# step = 24/104, χ = 62, |ψ| = 1.379 MB, RSS = 30.530 MB, Δt = 1.444 s
# step = 25/104, χ = 63, |ψ| = 1.410 MB, RSS = 31.181 MB, Δt = 1.418 s
# step = 26/104, χ = 63, |ψ| = 1.440 MB, RSS = 32.680 MB, Δt = 1.410 s
# step = 27/104, χ = 64, |ψ| = 1.499 MB, RSS = 32.978 MB, Δt = 1.398 s
# step = 28/104, χ = 65, |ψ| = 1.535 MB, RSS = 34.778 MB, Δt = 1.385 s
# step = 29/104, χ = 67, |ψ| = 1.601 MB, RSS = 35.558 MB, Δt = 1.375 s
# step = 30/104, χ = 69, |ψ| = 1.697 MB, RSS = 36.562 MB, Δt = 1.370 s
# step = 31/104, χ = 71, |ψ| = 1.792 MB, RSS = 38.097 MB, Δt = 1.359 s
# step = 32/104, χ = 74, |ψ| = 1.913 MB, RSS = 40.892 MB, Δt = 1.350 s
# step = 33/104, χ = 78, |ψ| = 2.104 MB, RSS = 42.597 MB, Δt = 1.353 s
# step = 34/104, χ = 83, |ψ| = 2.388 MB, RSS = 49.277 MB, Δt = 1.355 s
# step = 35/104, χ = 88, |ψ| = 2.593 MB, RSS = 51.094 MB, Δt = 1.329 s
# step = 36/104, χ = 94, |ψ| = 2.964 MB, RSS = 54.926 MB, Δt = 1.336 s
# step = 37/104, χ = 100, |ψ| = 3.391 MB, RSS = 60.737 MB, Δt = 1.336 s
# step = 38/104, χ = 107, |ψ| = 3.824 MB, RSS = 67.174 MB, Δt = 1.345 s
# step = 39/104, χ = 112, |ψ| = 4.199 MB, RSS = 74.498 MB, Δt = 1.354 s
# step = 40/104, χ = 118, |ψ| = 4.662 MB, RSS = 81.944 MB, Δt = 1.357 s
# step = 41/104, χ = 124, |ψ| = 5.162 MB, RSS = 88.792 MB, Δt = 1.344 s
# step = 42/104, χ = 130, |ψ| = 5.644 MB, RSS = 95.638 MB, Δt = 1.340 s
# step = 43/104, χ = 136, |ψ| = 6.154 MB, RSS = 106.922 MB, Δt = 1.302 s
# step = 44/104, χ = 143, |ψ| = 6.739 MB, RSS = 116.549 MB, Δt = 1.310 s
# step = 45/104, χ = 152, |ψ| = 7.440 MB, RSS = 123.796 MB, Δt = 1.319 s
# step = 46/104, χ = 162, |ψ| = 8.325 MB, RSS = 141.236 MB, Δt = 1.339 s
# step = 47/104, χ = 174, |ψ| = 9.507 MB, RSS = 155.546 MB, Δt = 1.347 s
# step = 48/104, χ = 189, |ψ| = 11.047 MB, RSS = 184.004 MB, Δt = 1.371 s
# step = 49/104, χ = 207, |ψ| = 12.982 MB, RSS = 216.110 MB, Δt = 1.418 s
# step = 50/104, χ = 225, |ψ| = 15.107 MB, RSS = 246.533 MB, Δt = 1.478 s
# step = 51/104, χ = 243, |ψ| = 17.456 MB, RSS = 282.864 MB, Δt = 1.551 s
# step = 52/104, χ = 263, |ψ| = 19.933 MB, RSS = 327.382 MB, Δt = 1.627 s
# step = 53/104, χ = 284, |ψ| = 22.771 MB, RSS = 373.781 MB, Δt = 1.698 s
# step = 54/104, χ = 307, |ψ| = 25.992 MB, RSS = 431.000 MB, Δt = 1.796 s
# step = 55/104, χ = 331, |ψ| = 29.635 MB, RSS = 495.561 MB, Δt = 1.892 s
# step = 56/104, χ = 356, |ψ| = 33.827 MB, RSS = 561.787 MB, Δt = 2.006 s
# step = 57/104, χ = 385, |ψ| = 38.817 MB, RSS = 645.727 MB, Δt = 2.170 s
# step = 58/104, χ = 417, |ψ| = 45.197 MB, RSS = 746.983 MB, Δt = 2.376 s
# step = 59/104, χ = 450, |ψ| = 52.002 MB, RSS = 879.014 MB, Δt = 2.648 s
# step = 60/104, χ = 486, |ψ| = 59.227 MB, RSS = 1012.275 MB, Δt = 2.901 s
# step = 61/104, χ = 520, |ψ| = 66.925 MB, RSS = 1154.683 MB, Δt = 3.192 s
# step = 62/104, χ = 554, |ψ| = 74.775 MB, RSS = 1306.201 MB, Δt = 3.559 s
# step = 63/104, χ = 589, |ψ| = 83.217 MB, RSS = 1470.735 MB, Δt = 3.951 s
# step = 64/104, χ = 625, |ψ| = 92.122 MB, RSS = 1638.282 MB, Δt = 4.348 s
# step = 65/104, χ = 659, |ψ| = 101.021 MB, RSS = 1822.982 MB, Δt = 4.801 s
# step = 66/104, χ = 690, |ψ| = 109.395 MB, RSS = 1999.977 MB, Δt = 5.269 s
# step = 67/104, χ = 718, |ψ| = 117.001 MB, RSS = 2165.020 MB, Δt = 5.656 s
# step = 68/104, χ = 744, |ψ| = 124.255 MB, RSS = 2326.298 MB, Δt = 6.113 s
# step = 69/104, χ = 766, |ψ| = 130.532 MB, RSS = 2471.341 MB, Δt = 6.510 s
# step = 70/104, χ = 786, |ψ| = 136.303 MB, RSS = 2600.082 MB, Δt = 6.887 s
# step = 71/104, χ = 805, |ψ| = 141.938 MB, RSS = 2723.514 MB, Δt = 7.348 s
# step = 72/104, χ = 827, |ψ| = 148.228 MB, RSS = 2849.696 MB, Δt = 7.614 s
# step = 73/104, χ = 850, |ψ| = 155.738 MB, RSS = 2948.115 MB, Δt = 7.716 s
# step = 74/104, χ = 876, |ψ| = 164.585 MB, RSS = 3117.575 MB, Δt = 8.096 s
# step = 75/104, χ = 903, |ψ| = 173.791 MB, RSS = 3293.865 MB, Δt = 8.634 s
# step = 76/104, χ = 928, |ψ| = 183.252 MB, RSS = 3480.279 MB, Δt = 9.261 s
# step = 77/104, χ = 954, |ψ| = 192.811 MB, RSS = 3678.874 MB, Δt = 9.868 s
# step = 78/104, χ = 981, |ψ| = 201.830 MB, RSS = 3865.429 MB, Δt = 10.524 s
# step = 79/104, χ = 1005, |ψ| = 210.348 MB, RSS = 4057.973 MB, Δt = 11.120 s
# step = 80/104, χ = 1024, |ψ| = 218.204 MB, RSS = 4236.412 MB, Δt = 11.646 s
# step = 81/104, χ = 1024, |ψ| = 225.890 MB, RSS = 4401.848 MB, Δt = 12.136 s
# step = 82/104, χ = 1024, |ψ| = 233.392 MB, RSS = 4573.542 MB, Δt = 12.620 s
# step = 83/104, χ = 1024, |ψ| = 239.443 MB, RSS = 4694.354 MB, Δt = 13.002 s
# step = 84/104, χ = 1024, |ψ| = 246.154 MB, RSS = 4755.108 MB, Δt = 12.992 s
# step = 85/104, χ = 1024, |ψ| = 253.733 MB, RSS = 4812.292 MB, Δt = 12.685 s
# step = 86/104, χ = 1024, |ψ| = 262.184 MB, RSS = 4957.738 MB, Δt = 13.114 s
# step = 87/104, χ = 1024, |ψ| = 268.122 MB, RSS = 5043.748 MB, Δt = 13.559 s
# step = 88/104, χ = 1024, |ψ| = 273.417 MB, RSS = 5096.627 MB, Δt = 13.671 s
# step = 89/104, χ = 1024, |ψ| = 279.199 MB, RSS = 5141.561 MB, Δt = 13.969 s
# step = 90/104, χ = 1024, |ψ| = 285.549 MB, RSS = 5194.150 MB, Δt = 14.292 s
# step = 91/104, χ = 1024, |ψ| = 292.499 MB, RSS = 5251.193 MB, Δt = 14.650 s
# step = 92/104, χ = 1024, |ψ| = 299.961 MB, RSS = 5314.084 MB, Δt = 15.066 s
# step = 93/104, χ = 1024, |ψ| = 306.428 MB, RSS = 5384.969 MB, Δt = 15.419 s
# step = 94/104, χ = 1024, |ψ| = 309.993 MB, RSS = 5430.231 MB, Δt = 15.650 s
# step = 95/104, χ = 1024, |ψ| = 313.221 MB, RSS = 5461.121 MB, Δt = 15.753 s
# step = 96/104, χ = 1024, |ψ| = 316.242 MB, RSS = 5484.884 MB, Δt = 15.904 s
# step = 97/104, χ = 1024, |ψ| = 318.605 MB, RSS = 5509.573 MB, Δt = 16.047 s
# step = 98/104, χ = 1024, |ψ| = 320.377 MB, RSS = 5598.884 MB, Δt = 16.774 s
# step = 99/104, χ = 1024, |ψ| = 321.365 MB, RSS = 5611.871 MB, Δt = 17.836 s
# step = 100/104, χ = 1024, |ψ| = 321.565 MB, RSS = 5617.234 MB, Δt = 17.920 s
# step = 101/104, χ = 1024, |ψ| = 321.565 MB, RSS = 5617.488 MB, Δt = 17.971 s
# step = 102/104, χ = 1024, |ψ| = 321.459 MB, RSS = 5619.588 MB, Δt = 17.983 s
# step = 103/104, χ = 1024, |ψ| = 321.407 MB, RSS = 5619.588 MB, Δt = 17.980 s
# step = 104/104, χ = 1024, |ψ| = 319.588 MB, RSS = 5619.588 MB, Δt = 12.889 s
#
# real	9m51.568s
# user	9m49.693s
# sys	0m4.746s


```
