### PR TITLE
Fix releases off of different sources

### DIFF
--- a/.github/workflows/publish_emu_mps.yml
+++ b/.github/workflows/publish_emu_mps.yml
@@ -7,7 +7,7 @@ on:
     types:
       - completed
 concurrency:
-  group: fast-${{ github.head_ref || github.run_id }}
+  group: fast-${{ github.event.workflow_run.head_sha || github.run_id }}
   cancel-in-progress: true
 
 jobs:
@@ -22,7 +22,7 @@ jobs:
       - name: Check emulators
         uses: actions/checkout@v4
         with:
-          ref: ${{ github.ref }}
+          ref: ${{ github.event.workflow_run.head_sha }}
       - name: Set up Python 3.10
         uses: actions/setup-python@v5
         with:

--- a/.github/workflows/publish_emu_sv.yml
+++ b/.github/workflows/publish_emu_sv.yml
@@ -7,7 +7,7 @@ on:
     types:
       - completed
 concurrency:
-  group: fast-${{ github.head_ref || github.run_id }}
+  group: fast-${{ github.event.workflow_run.head_sha || github.run_id }}
   cancel-in-progress: true
 
 jobs:
@@ -22,7 +22,7 @@ jobs:
       - name: Check emulators
         uses: actions/checkout@v4
         with:
-          ref: ${{ github.ref }}
+          ref: ${{ github.event.workflow_run.head_sha }}
       - name: Set up Python 3.10
         uses: actions/setup-python@v5
         with:


### PR DESCRIPTION
Make sure that emu-sv and emu-mps are released from the right sources tagged with the release tag, and not the current state of main.