### PR TITLE
optimatrix fails after checkpointing

### DIFF
--- a/emu_mps/mps_backend_impl.py
+++ b/emu_mps/mps_backend_impl.py
@@ -567,9 +567,14 @@ def permute_occupations_and_correlations(results: Results, perm: torch.Tensor) -
 
         uuid_corr = results._find_uuid(corr)
         corrs = results._results[uuid_corr]
-        results._results[uuid_corr] = [
-            optimat.permute_tensor(corr, perm) for corr in corrs
-        ]
+        results._results[uuid_corr] = (
+            [  # vector quantities become lists after results are serialized (e.g. for checkpoints)
+                optimat.permute_tensor(
+                    corr if isinstance(corr, torch.Tensor) else torch.tensor(corr), perm
+                )
+                for corr in corrs
+            ]
+        )
 
 
 def permute_atom_order(results: Results, perm: torch.Tensor) -> None:

--- a/test/emu_mps/test_mps_backend_impl.py
+++ b/test/emu_mps/test_mps_backend_impl.py
@@ -327,12 +327,23 @@ def test_init_hamiltonian(update_H_mock, make_H_mock):
     assert update_H_mock.call_count == 1
 
 
-def test_permute_results() -> None:
+@pytest.mark.parametrize(
+    "list",
+    [
+        False,
+        True,
+    ],
+)
+def test_permute_results(list: bool) -> None:
     obs = ["bitstrings", "occupation", "correlation_matrix"]
     # I use list of for obs to mimic [obs_t0 and obs_t1]
     bitstrings = [Counter({"110": 1, "010": 2}), Counter({"110": 3, "010": 4})]
     occup = [torch.tensor([0.1, 0.2, 0.3]), torch.tensor([0.4, 0.5, 0.6])]
     corr = [torch.outer(occup[0], occup[0]), torch.outer(occup[1], occup[1])]
+
+    if list:
+        occup = [x.tolist() for x in occup]
+        corr = [x.tolist() for x in corr]
 
     mock_results = MagicMock()
     mock_results.atom_order = ("q0", "q1", "q2")


### PR DESCRIPTION
To serialize the results for checkpointing, `torch.Tensor` objects in `Occupation` and `CorrelationMatrix` are converted into lists. The results permutation fails on this currently. Added a test that fails on the problem, and fixed it.