### PR TITLE
fix monkeypatch on save

### DIFF
--- a/emu_mps/mps_backend_impl.py
+++ b/emu_mps/mps_backend_impl.py
@@ -170,8 +170,10 @@ class MPSBackendImpl:
 
     def __getstate__(self) -> dict:
         d = self.__dict__.copy()
-        self.config = deepcopy(self.config)
-        for obs in d["config"].observables:
+        cp = deepcopy(self.config)
+        d["config"] = cp
+        d["state"].config = cp
+        for obs in cp.observables:
             obs.apply = MethodType(type(obs).apply, obs)  # type: ignore[method-assign]
         # mypy thinks the method below is an attribute, because of the __getattr__ override
         d["results"] = self.results._to_abstract_repr()  # type: ignore[operator]

--- a/emu_mps/mps_backend_impl.py
+++ b/emu_mps/mps_backend_impl.py
@@ -7,6 +7,7 @@ import time
 import typing
 import uuid
 
+from copy import deepcopy
 from collections import Counter
 from enum import Enum, auto
 from resource import RUSAGE_SELF, getrusage
@@ -168,9 +169,10 @@ class MPSBackendImpl:
             )
 
     def __getstate__(self) -> dict:
-        for obs in self.config.observables:
-            obs.apply = MethodType(type(obs).apply, obs)  # type: ignore[method-assign]
         d = self.__dict__.copy()
+        self.config = deepcopy(self.config)
+        for obs in d["config"].observables:
+            obs.apply = MethodType(type(obs).apply, obs)  # type: ignore[method-assign]
         # mypy thinks the method below is an attribute, because of the __getattr__ override
         d["results"] = self.results._to_abstract_repr()  # type: ignore[operator]
         return d

--- a/test/emu_mps/test_endtoend.py
+++ b/test/emu_mps/test_endtoend.py
@@ -731,6 +731,8 @@ def test_obs_after_autosave() -> None:
 
     evaluation_times = [1.0 / 30.0, 1.0 / 3.0, 0.5]
     energy = Energy(evaluation_times=evaluation_times)
+    correlation = CorrelationMatrix(evaluation_times=evaluation_times)
+    occupation = Occupation(evaluation_times=evaluation_times)
 
     save_simulation_original = MPSBackendImpl.save_simulation
 
@@ -743,4 +745,9 @@ def test_obs_after_autosave() -> None:
     ) as save_simulation_mock:
         save_simulation_mock.side_effect = save_simulation_mock_side_effect
 
-        MPSBackend(seq, config=MPSConfig(observables=[energy])).run()
+        results = MPSBackend(
+            seq, config=MPSConfig(observables=[energy, correlation, occupation])
+        ).run()
+    assert all([isinstance(x, torch.Tensor) for x in results.energy])
+    assert all([isinstance(x, torch.Tensor) for x in results.occupation])
+    assert all([isinstance(x, torch.Tensor) for x in results.correlation_matrix])


### PR DESCRIPTION
The `get_state` method of `MPSBackendImpl` destoys the monkeypatching of the observables. This expresses itself during the checkpointing.