### PR TITLE
Make deallocate_tensor safer and work with views

### DIFF
--- a/emu_base/utils.py
+++ b/emu_base/utils.py
@@ -21,6 +21,23 @@ def deallocate_tensor(t: torch.Tensor) -> None:
 
     After calling that function, the Tensor object
     should no longer be used.
+
+    To work properly with e.g. tensordot but also user-created views,
+    and since every view of a tensor owns the tensor's storage independently,
+    it has to change the storage of the base AND every view referring to the base.
+    However, it is not possible to access the views from the base, so
+    if there are extra inaccessible views, it will raise an exception.
     """
+    if (t._base is None and t._use_count() > 1) or (  # type: ignore[attr-defined]
+        t._base is not None and t._base._use_count() > 2  # type: ignore[attr-defined]
+    ):
+        raise RuntimeError("Cannot deallocate tensor")
+
+    replacement_storage = torch.zeros(0, dtype=t.dtype, device=t.device).untyped_storage()
+
     t.resize_(0)
-    t.set_(source=torch.zeros(0, dtype=t.dtype, device=t.device).untyped_storage())
+    t.set_(source=replacement_storage)
+
+    if t._base is not None:
+        t._base.resize_(0)
+        t._base.set_(source=replacement_storage)

--- a/emu_mps/mps_backend_impl.py
+++ b/emu_mps/mps_backend_impl.py
@@ -20,6 +20,7 @@ from pulser.backend import EmulationConfig, Observable, Results, State
 
 from emu_base import DEVICE_COUNT, PulserData
 from emu_base.math.brents_root_finding import BrentsRootFinder
+from emu_base.utils import deallocate_tensor
 
 from emu_mps.hamiltonian import make_H, update_H
 from emu_mps.mpo import MPO
@@ -415,7 +416,7 @@ class MPSBackendImpl:
             )
             if not self.has_lindblad_noise:
                 # Free memory because it won't be used anymore
-                self.right_baths[-2] = torch.zeros(0)
+                deallocate_tensor(self.right_baths[-2])
 
             self._evolve(self.tdvp_index, dt=-delta_time / 2)
             self.left_baths.pop()

--- a/emu_mps/tdvp.py
+++ b/emu_mps/tdvp.py
@@ -122,8 +122,10 @@ def evolve_pair(
 
     # Computation is done on left_device (arbitrary)
 
+    right_state_factor = right_state_factor.to(left_device)
+
     combined_state_factors = torch.tensordot(
-        left_state_factor, right_state_factor.to(left_device), dims=1
+        left_state_factor, right_state_factor, dims=1
     ).reshape(left_bond_dim, 4, right_bond_dim)
 
     deallocate_tensor(left_state_factor)

--- a/emu_mps/utils.py
+++ b/emu_mps/utils.py
@@ -53,7 +53,7 @@ def split_tensor(
             _determine_cutoff_index(d, max_error),
             d.shape[0] - max_rank,
         )
-        right = q.T.conj()[max_bond:, :]
+        right = q[:, max_bond:].T.conj_physical()
         left = m @ q
         left = left[:, max_bond:]
 

--- a/emu_sv/sv_backend.py
+++ b/emu_sv/sv_backend.py
@@ -54,7 +54,11 @@ class SVBackend(EmulatorBackend):
         else:
             state = StateVector.make(nqubits, gpu=self._config.gpu)
 
-        stepper = EvolveStateVector.apply
+        stepper = (
+            EvolveStateVector.apply
+            if state.vector.requires_grad
+            else EvolveStateVector.evolve
+        )
         for step in range(nsteps):
             dt = self.target_times[step + 1] - self.target_times[step]
             state.vector, H = stepper(

--- a/emu_sv/time_evolution.py
+++ b/emu_sv/time_evolution.py
@@ -123,6 +123,33 @@ class EvolveStateVector(torch.autograd.Function):
     """Custom autograd implementation of a step in the time evolution."""
 
     @staticmethod
+    def evolve(
+        dt: float,
+        omegas: torch.Tensor,
+        deltas: torch.Tensor,
+        phis: torch.Tensor,
+        interaction_matrix: torch.Tensor,
+        state: torch.Tensor,
+        krylov_tolerance: float,
+    ) -> tuple[torch.Tensor, RydbergHamiltonian]:
+        ham = RydbergHamiltonian(
+            omegas=omegas,
+            deltas=deltas,
+            phis=phis,
+            interaction_matrix=interaction_matrix,
+            device=state.device,
+        )
+        op = lambda x: -1j * dt * (ham * x)
+        res = krylov_exp(
+            op,
+            state,
+            norm_tolerance=krylov_tolerance,
+            exp_tolerance=krylov_tolerance,
+            is_hermitian=True,
+        )
+        return res, ham
+
+    @staticmethod
     def forward(
         ctx: Any,
         dt: float,
@@ -150,20 +177,8 @@ class EvolveStateVector(torch.autograd.Function):
             state (Tensor): input state to be evolved
             krylov_tolerance (float):
         """
-        ham = RydbergHamiltonian(
-            omegas=omegas,
-            deltas=deltas,
-            phis=phis,
-            interaction_matrix=interaction_matrix,
-            device=state.device,
-        )
-        op = lambda x: -1j * dt * (ham * x)
-        res = krylov_exp(
-            op,
-            state,
-            norm_tolerance=krylov_tolerance,
-            exp_tolerance=krylov_tolerance,
-            is_hermitian=True,
+        res, ham = EvolveStateVector.evolve(
+            dt, omegas, deltas, phis, interaction_matrix, state, krylov_tolerance
         )
         ctx.save_for_backward(omegas, deltas, phis, interaction_matrix, state)
         ctx.dt = dt
@@ -301,7 +316,7 @@ class EvolveStateVector(torch.autograd.Function):
 
         if ctx.needs_input_grad[5]:
             op = lambda x: (1j * dt) * (ham * x)
-            grad_state_in = krylov_exp(op, grad_state_out, tolerance, tolerance)
+            grad_state_in = krylov_exp(op, grad_state_out.detach(), tolerance, tolerance)
 
         return (
             None,

--- a/test/emu_base/test_utils.py
+++ b/test/emu_base/test_utils.py
@@ -32,3 +32,83 @@ def test_deallocate_tensor_free_gpu_memory():
 
     # t's memory is gone even though the object still exists for Python
     # (as referenced by the `t` name)
+
+
+def test_deallocate_view():
+    t = torch.ones(100, 100, dtype=torch.complex128)
+
+    t_view = t.view(-1)
+
+    deallocate_tensor(t_view)
+
+    assert len(t_view.shape) == len(t.shape) == 1
+    assert t_view.shape[0] == t.shape[0] == 0
+
+
+def test_deallocate_base_with_view():
+    t = torch.ones(100, 100, dtype=torch.complex128)
+
+    t_view = t.view(-1)
+
+    with pytest.raises(RuntimeError) as e:
+        deallocate_tensor(t)
+
+    assert str(e.value) == "Cannot deallocate tensor"
+
+    del t_view
+
+    deallocate_tensor(t)
+
+
+def test_deallocate_stacked_views():
+    t = torch.ones(100, 100, dtype=torch.complex128)
+
+    t_many_view = t.view(-1).view(20, 500).view(2, 5000)
+
+    # The base tensor always has _base == None
+    assert t_many_view._base._base is None
+    assert t_many_view._base is t
+
+    deallocate_tensor(t_many_view)
+
+    assert len(t_many_view.shape) == len(t.shape) == 1
+    assert t_many_view.shape[0] == t.shape[0] == 0
+
+
+def test_deallocate_multiple_independent_views():
+    t = torch.ones(100, 100, dtype=torch.complex128)
+
+    t_view_1 = t.view(-1)
+
+    # The second view prevents deallocation.
+    t_view_2 = t.view(-1)
+
+    with pytest.raises(RuntimeError) as e:
+        deallocate_tensor(t_view_1)
+
+    assert str(e.value) == "Cannot deallocate tensor"
+
+    del t_view_2
+
+    # Now it works.
+    deallocate_tensor(t_view_1)
+
+    assert len(t_view_1.shape) == len(t.shape) == 1
+    assert t_view_1.shape[0] == t.shape[0] == 0
+
+
+@pytest.mark.skipif(
+    not torch.cuda.is_available(), reason="This test needs a GPU with CUDA installed"
+)
+def test_deallocate_tensordot():
+    id = torch.eye(100, device="cuda:0")
+
+    original_memory_allocated = torch.cuda.memory_allocated()
+
+    m = torch.tensordot(id, id, dims=1)
+
+    deallocate_tensor(m)
+
+    torch._C._cuda_clearCublasWorkspaces()  # tensordot allocates extra memory on first use
+
+    assert torch.cuda.memory_allocated() == original_memory_allocated

--- a/test/emu_sv/test_time_evolution.py
+++ b/test/emu_sv/test_time_evolution.py
@@ -56,7 +56,7 @@ def get_randn_state(
 def test_forward(N: int, tolerance: float, with_phase: bool) -> None:
     torch.manual_seed(1337)
     ham_params = get_randn_ham_params(N, with_phase=with_phase)
-    state_in = get_randn_state(N, device=device)
+    state_in = get_randn_state(N, device=device, requires_grad=True)
     dt = 1.0  # 1 μs big time step
 
     expected = do_dense_time_step(dt, *ham_params, state_in)


### PR DESCRIPTION
`deallocate_tensor` would not work with views. For that, the `_base` tensor of a view needs to have its storage set to zero as well otherwise the storage stays alive.

I added an exception when `deallocate_tensor` could not free the memory because some other thing was pointing to the data, using `_use_count()`. It is not possible to know all views which exist and free them, so failing seemed the best solution instead of silently skipping the actual deallocation.

This allowed finding cases where _the data was not properly deallocated_, namely `deallocate_tensor(right_state_factor)` in `evolve_pair`, which was caused by a `.conj()` in `split_tensor` in the `orth_center_right=False` path creating multiple views... Still unclear why.
So this change further reduces max memory usage in emu-mps by this `right_state_factor`. See below.


Before:
```
step = 1/85, χ = 3, |ψ| = 0.007 MB, RSS = 9.294 MB, Δt = 1.401 s
step = 2/85, χ = 3, |ψ| = 0.007 MB, RSS = 9.325 MB, Δt = 0.856 s
step = 3/85, χ = 3, |ψ| = 0.007 MB, RSS = 9.325 MB, Δt = 0.848 s
step = 4/85, χ = 4, |ψ| = 0.009 MB, RSS = 9.338 MB, Δt = 0.867 s
step = 5/85, χ = 4, |ψ| = 0.012 MB, RSS = 9.343 MB, Δt = 0.902 s
step = 6/85, χ = 4, |ψ| = 0.012 MB, RSS = 9.348 MB, Δt = 0.926 s
step = 7/85, χ = 5, |ψ| = 0.014 MB, RSS = 9.350 MB, Δt = 1.036 s
step = 8/85, χ = 5, |ψ| = 0.014 MB, RSS = 9.400 MB, Δt = 0.978 s
step = 9/85, χ = 5, |ψ| = 0.018 MB, RSS = 9.400 MB, Δt = 0.640 s
step = 10/85, χ = 5, |ψ| = 0.018 MB, RSS = 9.400 MB, Δt = 1.129 s
step = 11/85, χ = 6, |ψ| = 0.021 MB, RSS = 9.431 MB, Δt = 1.195 s
step = 12/85, χ = 5, |ψ| = 0.018 MB, RSS = 9.431 MB, Δt = 1.185 s
step = 13/85, χ = 6, |ψ| = 0.023 MB, RSS = 9.431 MB, Δt = 1.200 s
step = 14/85, χ = 6, |ψ| = 0.025 MB, RSS = 9.455 MB, Δt = 1.234 s
step = 15/85, χ = 6, |ψ| = 0.025 MB, RSS = 9.455 MB, Δt = 1.178 s
step = 16/85, χ = 7, |ψ| = 0.028 MB, RSS = 9.457 MB, Δt = 1.182 s
step = 17/85, χ = 6, |ψ| = 0.025 MB, RSS = 9.485 MB, Δt = 0.789 s
step = 18/85, χ = 6, |ψ| = 0.025 MB, RSS = 9.485 MB, Δt = 0.812 s
step = 19/85, χ = 7, |ψ| = 0.027 MB, RSS = 9.485 MB, Δt = 1.136 s
step = 20/85, χ = 6, |ψ| = 0.025 MB, RSS = 9.485 MB, Δt = 1.088 s
step = 21/85, χ = 7, |ψ| = 0.031 MB, RSS = 9.485 MB, Δt = 1.111 s
step = 22/85, χ = 7, |ψ| = 0.027 MB, RSS = 9.501 MB, Δt = 1.079 s
step = 23/85, χ = 7, |ψ| = 0.028 MB, RSS = 9.501 MB, Δt = 1.077 s
step = 24/85, χ = 7, |ψ| = 0.027 MB, RSS = 9.503 MB, Δt = 1.083 s
step = 25/85, χ = 7, |ψ| = 0.025 MB, RSS = 9.503 MB, Δt = 1.021 s
step = 26/85, χ = 6, |ψ| = 0.025 MB, RSS = 9.503 MB, Δt = 0.547 s
step = 27/85, χ = 8, |ψ| = 0.037 MB, RSS = 9.503 MB, Δt = 0.918 s
step = 28/85, χ = 8, |ψ| = 0.034 MB, RSS = 9.544 MB, Δt = 1.036 s
step = 29/85, χ = 7, |ψ| = 0.028 MB, RSS = 9.544 MB, Δt = 0.999 s
step = 30/85, χ = 9, |ψ| = 0.049 MB, RSS = 9.558 MB, Δt = 1.039 s
step = 31/85, χ = 9, |ψ| = 0.046 MB, RSS = 9.639 MB, Δt = 0.991 s
step = 32/85, χ = 9, |ψ| = 0.046 MB, RSS = 9.639 MB, Δt = 0.980 s
step = 33/85, χ = 9, |ψ| = 0.052 MB, RSS = 9.663 MB, Δt = 0.990 s
step = 34/85, χ = 10, |ψ| = 0.059 MB, RSS = 9.723 MB, Δt = 0.982 s
step = 35/85, χ = 11, |ψ| = 0.070 MB, RSS = 9.731 MB, Δt = 0.941 s
step = 36/85, χ = 11, |ψ| = 0.070 MB, RSS = 9.842 MB, Δt = 0.950 s
step = 37/85, χ = 12, |ψ| = 0.086 MB, RSS = 9.870 MB, Δt = 0.956 s
step = 38/85, χ = 12, |ψ| = 0.087 MB, RSS = 9.948 MB, Δt = 0.934 s
step = 39/85, χ = 13, |ψ| = 0.099 MB, RSS = 9.980 MB, Δt = 0.906 s
step = 40/85, χ = 14, |ψ| = 0.108 MB, RSS = 10.081 MB, Δt = 0.933 s
step = 41/85, χ = 15, |ψ| = 0.128 MB, RSS = 10.251 MB, Δt = 0.946 s
step = 42/85, χ = 16, |ψ| = 0.130 MB, RSS = 10.288 MB, Δt = 0.860 s
step = 43/85, χ = 15, |ψ| = 0.124 MB, RSS = 10.288 MB, Δt = 0.557 s
step = 44/85, χ = 17, |ψ| = 0.164 MB, RSS = 10.483 MB, Δt = 0.957 s
step = 45/85, χ = 19, |ψ| = 0.187 MB, RSS = 10.716 MB, Δt = 0.971 s
step = 46/85, χ = 21, |ψ| = 0.226 MB, RSS = 11.086 MB, Δt = 0.981 s
step = 47/85, χ = 23, |ψ| = 0.253 MB, RSS = 11.635 MB, Δt = 0.999 s
step = 48/85, χ = 24, |ψ| = 0.283 MB, RSS = 11.867 MB, Δt = 0.974 s
step = 49/85, χ = 26, |ψ| = 0.344 MB, RSS = 12.355 MB, Δt = 0.979 s
step = 50/85, χ = 29, |ψ| = 0.393 MB, RSS = 12.962 MB, Δt = 0.997 s
step = 51/85, χ = 28, |ψ| = 0.371 MB, RSS = 13.376 MB, Δt = 0.788 s
step = 52/85, χ = 28, |ψ| = 0.385 MB, RSS = 13.376 MB, Δt = 0.783 s
step = 53/85, χ = 33, |ψ| = 0.504 MB, RSS = 14.049 MB, Δt = 1.033 s
step = 54/85, χ = 36, |ψ| = 0.580 MB, RSS = 15.272 MB, Δt = 1.045 s
step = 55/85, χ = 38, |ψ| = 0.658 MB, RSS = 17.324 MB, Δt = 1.053 s
step = 56/85, χ = 42, |ψ| = 0.764 MB, RSS = 18.107 MB, Δt = 1.096 s
step = 57/85, χ = 45, |ψ| = 0.854 MB, RSS = 19.077 MB, Δt = 1.113 s
step = 58/85, χ = 48, |ψ| = 0.942 MB, RSS = 20.221 MB, Δt = 1.117 s
step = 59/85, χ = 50, |ψ| = 1.036 MB, RSS = 21.571 MB, Δt = 1.120 s
step = 60/85, χ = 47, |ψ| = 0.933 MB, RSS = 21.571 MB, Δt = 0.731 s
step = 61/85, χ = 51, |ψ| = 1.052 MB, RSS = 21.571 MB, Δt = 0.952 s
step = 62/85, χ = 58, |ψ| = 1.314 MB, RSS = 23.997 MB, Δt = 1.095 s
step = 63/85, χ = 63, |ψ| = 1.495 MB, RSS = 27.407 MB, Δt = 1.102 s
step = 64/85, χ = 67, |ψ| = 1.675 MB, RSS = 29.692 MB, Δt = 1.070 s
step = 65/85, χ = 72, |ψ| = 1.903 MB, RSS = 33.625 MB, Δt = 1.053 s
step = 66/85, χ = 77, |ψ| = 2.122 MB, RSS = 37.267 MB, Δt = 1.038 s
step = 67/85, χ = 82, |ψ| = 2.352 MB, RSS = 41.701 MB, Δt = 1.036 s
step = 68/85, χ = 87, |ψ| = 2.594 MB, RSS = 47.265 MB, Δt = 1.041 s
step = 69/85, χ = 93, |ψ| = 2.911 MB, RSS = 51.954 MB, Δt = 1.045 s
step = 70/85, χ = 99, |ψ| = 3.266 MB, RSS = 54.884 MB, Δt = 1.043 s
step = 71/85, χ = 107, |ψ| = 3.700 MB, RSS = 61.761 MB, Δt = 1.026 s
step = 72/85, χ = 114, |ψ| = 4.091 MB, RSS = 67.521 MB, Δt = 1.019 s
step = 73/85, χ = 121, |ψ| = 4.496 MB, RSS = 75.146 MB, Δt = 1.014 s
step = 74/85, χ = 128, |ψ| = 4.981 MB, RSS = 82.729 MB, Δt = 1.023 s
step = 75/85, χ = 137, |ψ| = 5.521 MB, RSS = 89.735 MB, Δt = 1.035 s
step = 76/85, χ = 136, |ψ| = 5.464 MB, RSS = 96.283 MB, Δt = 0.957 s
step = 77/85, χ = 134, |ψ| = 5.281 MB, RSS = 96.283 MB, Δt = 0.730 s
step = 78/85, χ = 149, |ψ| = 6.361 MB, RSS = 102.892 MB, Δt = 1.049 s
step = 79/85, χ = 156, |ψ| = 6.889 MB, RSS = 112.601 MB, Δt = 1.046 s
step = 80/85, χ = 164, |ψ| = 7.422 MB, RSS = 123.884 MB, Δt = 1.051 s
step = 81/85, χ = 171, |ψ| = 7.906 MB, RSS = 133.827 MB, Δt = 1.071 s
step = 82/85, χ = 175, |ψ| = 8.275 MB, RSS = 141.374 MB, Δt = 1.092 s
step = 83/85, χ = 178, |ψ| = 8.500 MB, RSS = 148.589 MB, Δt = 1.102 s
step = 84/85, χ = 179, |ψ| = 8.542 MB, RSS = 153.512 MB, Δt = 1.105 s
step = 85/85, χ = 178, |ψ| = 8.489 MB, RSS = 153.512 MB, Δt = 0.922 s

real	1m28.100s
user	1m29.091s
sys	0m2.435s
```


After:
```
step = 1/85, χ = 3, |ψ| = 0.007 MB, RSS = 9.289 MB, Δt = 1.295 s
step = 2/85, χ = 3, |ψ| = 0.007 MB, RSS = 9.318 MB, Δt = 0.854 s
step = 3/85, χ = 3, |ψ| = 0.007 MB, RSS = 9.318 MB, Δt = 0.848 s
step = 4/85, χ = 4, |ψ| = 0.009 MB, RSS = 9.331 MB, Δt = 0.865 s
step = 5/85, χ = 4, |ψ| = 0.012 MB, RSS = 9.336 MB, Δt = 0.902 s
step = 6/85, χ = 4, |ψ| = 0.012 MB, RSS = 9.340 MB, Δt = 0.926 s
step = 7/85, χ = 5, |ψ| = 0.014 MB, RSS = 9.343 MB, Δt = 1.036 s
step = 8/85, χ = 5, |ψ| = 0.014 MB, RSS = 9.392 MB, Δt = 0.977 s
step = 9/85, χ = 5, |ψ| = 0.018 MB, RSS = 9.392 MB, Δt = 0.639 s
step = 10/85, χ = 5, |ψ| = 0.018 MB, RSS = 9.392 MB, Δt = 1.130 s
step = 11/85, χ = 6, |ψ| = 0.021 MB, RSS = 9.419 MB, Δt = 1.197 s
step = 12/85, χ = 5, |ψ| = 0.018 MB, RSS = 9.419 MB, Δt = 1.186 s
step = 13/85, χ = 6, |ψ| = 0.023 MB, RSS = 9.419 MB, Δt = 1.202 s
step = 14/85, χ = 6, |ψ| = 0.025 MB, RSS = 9.440 MB, Δt = 1.237 s
step = 15/85, χ = 6, |ψ| = 0.025 MB, RSS = 9.440 MB, Δt = 1.179 s
step = 16/85, χ = 7, |ψ| = 0.028 MB, RSS = 9.444 MB, Δt = 1.185 s
step = 17/85, χ = 6, |ψ| = 0.025 MB, RSS = 9.468 MB, Δt = 0.791 s
step = 18/85, χ = 6, |ψ| = 0.025 MB, RSS = 9.468 MB, Δt = 0.813 s
step = 19/85, χ = 7, |ψ| = 0.027 MB, RSS = 9.468 MB, Δt = 1.136 s
step = 20/85, χ = 6, |ψ| = 0.025 MB, RSS = 9.468 MB, Δt = 1.088 s
step = 21/85, χ = 7, |ψ| = 0.031 MB, RSS = 9.468 MB, Δt = 1.114 s
step = 22/85, χ = 7, |ψ| = 0.027 MB, RSS = 9.477 MB, Δt = 1.080 s
step = 23/85, χ = 7, |ψ| = 0.028 MB, RSS = 9.477 MB, Δt = 1.081 s
step = 24/85, χ = 7, |ψ| = 0.027 MB, RSS = 9.486 MB, Δt = 1.087 s
step = 25/85, χ = 7, |ψ| = 0.025 MB, RSS = 9.486 MB, Δt = 1.024 s
step = 26/85, χ = 6, |ψ| = 0.025 MB, RSS = 9.486 MB, Δt = 0.547 s
step = 27/85, χ = 8, |ψ| = 0.037 MB, RSS = 9.486 MB, Δt = 0.919 s
step = 28/85, χ = 8, |ψ| = 0.034 MB, RSS = 9.519 MB, Δt = 1.035 s
step = 29/85, χ = 7, |ψ| = 0.028 MB, RSS = 9.519 MB, Δt = 1.000 s
step = 30/85, χ = 9, |ψ| = 0.049 MB, RSS = 9.546 MB, Δt = 1.041 s
step = 31/85, χ = 9, |ψ| = 0.046 MB, RSS = 9.595 MB, Δt = 0.992 s
step = 32/85, χ = 9, |ψ| = 0.046 MB, RSS = 9.595 MB, Δt = 0.980 s
step = 33/85, χ = 9, |ψ| = 0.052 MB, RSS = 9.636 MB, Δt = 0.990 s
step = 34/85, χ = 10, |ψ| = 0.059 MB, RSS = 9.698 MB, Δt = 0.977 s
step = 35/85, χ = 11, |ψ| = 0.070 MB, RSS = 9.698 MB, Δt = 0.938 s
step = 36/85, χ = 11, |ψ| = 0.070 MB, RSS = 9.825 MB, Δt = 0.948 s
step = 37/85, χ = 12, |ψ| = 0.086 MB, RSS = 9.846 MB, Δt = 0.954 s
step = 38/85, χ = 12, |ψ| = 0.087 MB, RSS = 9.919 MB, Δt = 0.934 s
step = 39/85, χ = 13, |ψ| = 0.099 MB, RSS = 9.944 MB, Δt = 0.905 s
step = 40/85, χ = 14, |ψ| = 0.108 MB, RSS = 10.051 MB, Δt = 0.930 s
step = 41/85, χ = 15, |ψ| = 0.128 MB, RSS = 10.224 MB, Δt = 0.947 s
step = 42/85, χ = 16, |ψ| = 0.130 MB, RSS = 10.249 MB, Δt = 0.859 s
step = 43/85, χ = 15, |ψ| = 0.124 MB, RSS = 10.249 MB, Δt = 0.557 s
step = 44/85, χ = 17, |ψ| = 0.164 MB, RSS = 10.462 MB, Δt = 0.953 s
step = 45/85, χ = 19, |ψ| = 0.187 MB, RSS = 10.647 MB, Δt = 0.970 s
step = 46/85, χ = 21, |ψ| = 0.226 MB, RSS = 10.954 MB, Δt = 0.980 s
step = 47/85, χ = 23, |ψ| = 0.253 MB, RSS = 11.501 MB, Δt = 0.998 s
step = 48/85, χ = 24, |ψ| = 0.283 MB, RSS = 11.687 MB, Δt = 0.972 s
step = 49/85, χ = 26, |ψ| = 0.344 MB, RSS = 12.188 MB, Δt = 0.979 s
step = 50/85, χ = 29, |ψ| = 0.393 MB, RSS = 12.764 MB, Δt = 0.994 s
step = 51/85, χ = 28, |ψ| = 0.371 MB, RSS = 13.094 MB, Δt = 0.787 s
step = 52/85, χ = 28, |ψ| = 0.385 MB, RSS = 13.094 MB, Δt = 0.781 s
step = 53/85, χ = 33, |ψ| = 0.504 MB, RSS = 13.819 MB, Δt = 1.030 s
step = 54/85, χ = 36, |ψ| = 0.580 MB, RSS = 14.946 MB, Δt = 1.043 s
step = 55/85, χ = 38, |ψ| = 0.658 MB, RSS = 16.901 MB, Δt = 1.051 s
step = 56/85, χ = 42, |ψ| = 0.764 MB, RSS = 17.583 MB, Δt = 1.098 s
step = 57/85, χ = 45, |ψ| = 0.854 MB, RSS = 18.537 MB, Δt = 1.110 s
step = 58/85, χ = 48, |ψ| = 0.942 MB, RSS = 19.714 MB, Δt = 1.115 s
step = 59/85, χ = 50, |ψ| = 1.036 MB, RSS = 21.010 MB, Δt = 1.118 s
step = 60/85, χ = 47, |ψ| = 0.933 MB, RSS = 21.010 MB, Δt = 0.730 s
step = 61/85, χ = 51, |ψ| = 1.052 MB, RSS = 21.010 MB, Δt = 0.952 s
step = 62/85, χ = 58, |ψ| = 1.314 MB, RSS = 23.366 MB, Δt = 1.093 s
step = 63/85, χ = 63, |ψ| = 1.495 MB, RSS = 26.528 MB, Δt = 1.101 s
step = 64/85, χ = 67, |ψ| = 1.675 MB, RSS = 28.793 MB, Δt = 1.069 s
step = 65/85, χ = 72, |ψ| = 1.903 MB, RSS = 32.557 MB, Δt = 1.055 s
step = 66/85, χ = 77, |ψ| = 2.122 MB, RSS = 36.110 MB, Δt = 1.038 s
step = 67/85, χ = 82, |ψ| = 2.352 MB, RSS = 40.412 MB, Δt = 1.035 s
step = 68/85, χ = 87, |ψ| = 2.594 MB, RSS = 45.839 MB, Δt = 1.040 s
step = 69/85, χ = 93, |ψ| = 2.911 MB, RSS = 49.903 MB, Δt = 1.044 s
step = 70/85, χ = 99, |ψ| = 3.266 MB, RSS = 53.097 MB, Δt = 1.043 s
step = 71/85, χ = 107, |ψ| = 3.700 MB, RSS = 59.757 MB, Δt = 1.029 s
step = 72/85, χ = 114, |ψ| = 4.091 MB, RSS = 64.865 MB, Δt = 1.017 s
step = 73/85, χ = 121, |ψ| = 4.496 MB, RSS = 72.614 MB, Δt = 1.016 s
step = 74/85, χ = 128, |ψ| = 4.981 MB, RSS = 79.944 MB, Δt = 1.020 s
step = 75/85, χ = 137, |ψ| = 5.521 MB, RSS = 86.639 MB, Δt = 1.034 s
step = 76/85, χ = 136, |ψ| = 5.464 MB, RSS = 92.682 MB, Δt = 0.955 s
step = 77/85, χ = 134, |ψ| = 5.281 MB, RSS = 92.682 MB, Δt = 0.725 s
step = 78/85, χ = 149, |ψ| = 6.361 MB, RSS = 100.383 MB, Δt = 1.036 s
step = 79/85, χ = 156, |ψ| = 6.889 MB, RSS = 113.020 MB, Δt = 1.047 s
step = 80/85, χ = 164, |ψ| = 7.422 MB, RSS = 118.870 MB, Δt = 1.053 s
step = 81/85, χ = 171, |ψ| = 7.906 MB, RSS = 128.077 MB, Δt = 1.067 s
step = 82/85, χ = 175, |ψ| = 8.275 MB, RSS = 135.925 MB, Δt = 1.095 s
step = 83/85, χ = 178, |ψ| = 8.500 MB, RSS = 139.339 MB, Δt = 1.100 s
step = 84/85, χ = 179, |ψ| = 8.542 MB, RSS = 144.947 MB, Δt = 1.104 s
step = 85/85, χ = 178, |ψ| = 8.489 MB, RSS = 144.947 MB, Δt = 0.920 s

real	1m27.910s
user	1m29.142s
sys	0m2.700s
```