### PR TITLE
Minimize energy of the pair state

### DIFF
--- a/emu_mps/dmrg.py
+++ b/emu_mps/dmrg.py
@@ -1,0 +1,84 @@
+import torch
+
+from emu_base.math.krylov_energy_min import krylov_energy_minimization
+from emu_base.utils import deallocate_tensor
+from emu_mps import MPSConfig
+from emu_mps.utils import split_tensor
+from emu_mps.tdvp import apply_effective_Hamiltonian
+
+
+def minimize_energy_pair(
+    *,
+    state_factors: list[torch.Tensor],
+    baths: tuple[torch.Tensor, torch.Tensor],
+    ham_factors: list[torch.Tensor],
+    orth_center_right: bool,
+    is_hermitian: bool,
+    config: MPSConfig,
+    residual_tolerance: float,
+) -> tuple[torch.Tensor, torch.Tensor, float]:
+    """
+    Minimizes the state factors (ψ_i, ψ_{i+1}) using the Lanczos/Arnoldi method
+    """
+
+    assert len(state_factors) == 2
+    assert len(baths) == 2
+    assert len(ham_factors) == 2
+
+    left_state_factor, right_state_factor = state_factors
+    left_bath, right_bath = baths
+    left_ham_factor, right_ham_factor = ham_factors
+
+    left_device = left_state_factor.device
+    right_device = right_state_factor.device
+
+    left_bond_dim = left_state_factor.shape[0]
+    right_bond_dim = right_state_factor.shape[-1]
+
+    # Computation is done on left_device (arbitrary)
+
+    right_state_factor = right_state_factor.to(left_device)
+
+    combined_state_factors = torch.tensordot(
+        left_state_factor, right_state_factor, dims=1
+    ).reshape(left_bond_dim, 4, right_bond_dim)
+
+    deallocate_tensor(left_state_factor)
+    deallocate_tensor(right_state_factor)
+
+    left_ham_factor = left_ham_factor.to(left_device)
+    right_ham_factor = right_ham_factor.to(left_device)
+    right_bath = right_bath.to(left_device)
+
+    combined_hamiltonian_factors = (
+        torch.tensordot(left_ham_factor, right_ham_factor, dims=1)
+        .transpose(2, 3)
+        .reshape(left_ham_factor.shape[0], 4, 4, -1)
+    )
+
+    op = lambda x: apply_effective_Hamiltonian(
+        x, combined_hamiltonian_factors, left_bath, right_bath
+    )
+
+    updated_state, updated_energy = krylov_energy_minimization(
+        op,
+        combined_state_factors,
+        norm_tolerance=config.precision * config.extra_krylov_tolerance,
+        residual_tolerance=residual_tolerance,
+        max_krylov_dim=config.max_krylov_dim,
+        is_hermitian=is_hermitian,
+    )
+    updated_state = updated_state.view(left_bond_dim * 2, 2 * right_bond_dim)
+
+    l, r = split_tensor(
+        updated_state,
+        max_error=config.precision,
+        max_rank=config.max_bond_dim,
+        orth_center_right=orth_center_right,
+    )
+
+    return (
+        l.view(left_bond_dim, 2, -1),
+        r.view(-1, 2, right_bond_dim).to(right_device),
+        updated_energy,
+    )

--- a/test/emu_base/math/test_krylov_energy_min.py
+++ b/test/emu_base/math/test_krylov_energy_min.py
@@ -64,8 +64,7 @@ def check(
         expected_iteration_count,
         expected_iteration_count + 1,
     }
-
-    E_approx = result.ground_energy
+    E_approx = result.ground_energy.real if is_hermitian else result.ground_energy
     psi_approx = result.ground_state
 
     eigen_energy, eigen_state = torch.linalg.eigh(A)
@@ -150,7 +149,7 @@ def test_exact_case():
 
 
 def test_ising_hamiltonian():
-    N = 12
+    N = 8
     d = 2
     J, h = 1.0, 0.1
 
@@ -175,5 +174,5 @@ def test_ising_hamiltonian():
         residual_tolerance=1e-6,
         expect_converged=True,
         expect_happy_breakdown=False,
-        expected_iteration_count=98,
+        expected_iteration_count=62,
     )

--- a/test/emu_mps/test_dmrg.py
+++ b/test/emu_mps/test_dmrg.py
@@ -1,0 +1,51 @@
+import torch
+from emu_mps.mps_config import MPSConfig
+from emu_mps.dmrg import minimize_energy_pair
+
+dtype = torch.complex128
+
+
+def test_minimize_energy_pair():
+    left_bath = torch.rand(2, 2, 2, dtype=dtype)
+    right_bath = torch.rand(2, 3, 2, dtype=dtype)
+    left_state_factor = torch.rand(2, 2, 4, dtype=dtype)
+    right_state_factor = torch.rand(4, 2, 2, dtype=dtype)
+    left_ham_factor = torch.rand(2, 2, 2, 5, dtype=dtype)
+    right_ham_factor = torch.rand(5, 2, 2, 3, dtype=dtype)
+
+    left_state_factor_shape = left_state_factor.shape
+    right_state_factor_shape = right_state_factor.shape
+
+    op = torch.einsum(
+        "abc,bdef,fghi,jik->adgjcehk",
+        left_bath,
+        left_ham_factor,
+        right_ham_factor,
+        right_bath,
+    ).reshape(2 * 2 * 2 * 2, -1)
+
+    eigen_energy, _ = torch.linalg.eig(op)
+    idx0 = torch.argmin(eigen_energy.abs())
+    expected_energy = eigen_energy[idx0].item()
+
+    actual_left, actual_right, actual_energy = minimize_energy_pair(
+        state_factors=[left_state_factor, right_state_factor],
+        baths=[left_bath, right_bath],
+        ham_factors=[left_ham_factor, right_ham_factor],
+        config=MPSConfig(max_bond_dim=12),
+        is_hermitian=False,
+        orth_center_right=False,
+        residual_tolerance=1e-5,
+    )
+
+    # check that resulting state tensors have correct shapes
+    assert actual_left.shape == left_state_factor_shape
+    assert actual_right.shape == right_state_factor_shape
+
+    # check: norm of new state ~ 1
+    actual_state = torch.tensordot(actual_left, actual_right, dims=1).view(-1)
+    assert torch.isclose(actual_state.norm(), torch.tensor(1.0, dtype=float), atol=1e-8)
+
+    # check the resulting energy agains ED
+    assert abs(actual_energy.real - expected_energy.real) <= 1e-8
+    assert abs(actual_energy.imag - expected_energy.imag) <= 1e-8


### PR DESCRIPTION
- method minimize_energy_pair() that minimizes the energy of a consecutive MPS sites using the Lanczos/Arnoldi algorithm. 
-  a unittest that accounts for above
- fix in the Lanzcos algorithm to account for non-hermitian matrices 
