### PR TITLE
Use matmul in mps.apply instead of tensordot and transpose

### DIFF
--- a/emu_mps/mps.py
+++ b/emu_mps/mps.py
@@ -499,11 +499,10 @@ class MPS(State[complex, torch.Tensor]):
         """
         self.orthogonalize(qubit_index)
 
-        self.factors[qubit_index] = torch.tensordot(
-            self.factors[qubit_index],
-            single_qubit_operator.to(self.factors[qubit_index].device),
-            ([1], [1]),
-        ).transpose(1, 2)
+        self.factors[qubit_index] = (
+            single_qubit_operator.to(self.factors[qubit_index].device)
+            @ self.factors[qubit_index]
+        )
 
     def get_correlation_matrix(
         self, *, operator: torch.Tensor = n_operator

--- a/test/emu_mps/test_endtoend.py
+++ b/test/emu_mps/test_endtoend.py
@@ -480,7 +480,7 @@ def test_end_to_end_afm_ring_with_noise() -> None:
     )
 
     noise_model = pulser.noise_model.NoiseModel(
-        depolarizing_rate=0.1,
+        depolarizing_rate=0.3,  # High enough to trigger a jump.
     )
 
     result = simulate(seq, noise_model=noise_model)
@@ -489,8 +489,8 @@ def test_end_to_end_afm_ring_with_noise() -> None:
     final_state = result.state[-1]
     max_bond_dim = final_state.get_max_bond_dim()
 
-    assert bitstrings["101010"] == 472
-    assert bitstrings["010101"] == 510
+    assert bitstrings["101010"] == 454
+    assert bitstrings["010101"] == 500
     assert max_bond_dim == 8
 
 


### PR DESCRIPTION
This results in a contiguous tensor which was not the case before. Also update the noisy test to trigger a jump.