### PR TITLE
version bump and bugfix

### DIFF
--- a/CITATION.cff
+++ b/CITATION.cff
@@ -39,5 +39,5 @@ abstract: >-
 keywords:
   - analog quantum computing
   - emulation
-version: 2.2.0
+version: 2.2.1
 date-released: '2025-05-12'

--- a/ci/emu_mps/pyproject.toml
+++ b/ci/emu_mps/pyproject.toml
@@ -23,7 +23,7 @@ classifiers=[
 ]
 dynamic = ["version"]
 dependencies = [
-  "emu-base==2.2.0"]
+  "emu-base==2.2.1"]
 
 [project.urls]
 Documentation = "https://pasqal-io.github.io/emulators/"

--- a/ci/emu_sv/pyproject.toml
+++ b/ci/emu_sv/pyproject.toml
@@ -23,7 +23,7 @@ classifiers=[
 ]
 dynamic = ["version"]
 dependencies = [
-  "emu-base==2.2.0"]
+  "emu-base==2.2.1"]
 
 [project.urls]
 Documentation = "https://pasqal-io.github.io/emulators/"

--- a/emu_base/__init__.py
+++ b/emu_base/__init__.py
@@ -20,4 +20,4 @@ __all__ = [
     "DEVICE_COUNT",
 ]
 
-__version__ = "2.2.0"
+__version__ = "2.2.1"

--- a/emu_mps/__init__.py
+++ b/emu_mps/__init__.py
@@ -37,4 +37,4 @@ __all__ = [
     "EntanglementEntropy",
 ]
 
-__version__ = "2.2.0"
+__version__ = "2.2.1"

--- a/emu_mps/mpo.py
+++ b/emu_mps/mpo.py
@@ -1,5 +1,4 @@
 from __future__ import annotations
-import itertools
 from typing import Any, List, Sequence, Optional
 
 import torch
@@ -10,24 +9,6 @@ from emu_mps.algebra import add_factors, scale_factors, zip_right
 from pulser.backend.operator import FullOp, QuditOp
 from emu_mps.mps import MPS
 from emu_mps.utils import new_left_bath, assign_devices
-
-
-def _validate_operator_targets(operations: FullOp, nqubits: int) -> None:
-    for tensorop in operations:
-        target_qids = (factor[1] for factor in tensorop[1])
-        target_qids_list = list(itertools.chain(*target_qids))
-        target_qids_set = set(target_qids_list)
-        if len(target_qids_set) < len(target_qids_list):
-            # Either the qubit id has been defined twice in an operation:
-            for qids in target_qids:
-                if len(set(qids)) < len(qids):
-                    raise ValueError("Duplicate atom ids in argument list.")
-            # Or it was defined in two different operations
-            raise ValueError("Each qubit can be targeted by only one operation.")
-        if max(target_qids_set) >= nqubits:
-            raise ValueError(
-                "The operation targets more qubits than there are in the register."
-            )
 
 
 class MPO(Operator[complex, torch.Tensor, MPS]):
@@ -175,8 +156,6 @@ class MPO(Operator[complex, torch.Tensor, MPS]):
         Returns:
             the operator in MPO form.
         """
-
-        _validate_operator_targets(operations, n_qudits)
 
         basis = set(eigenstates)
 

--- a/emu_sv/__init__.py
+++ b/emu_sv/__init__.py
@@ -38,4 +38,4 @@ __all__ = [
     "DensityMatrix",
 ]
 
-__version__ = "2.2.0"
+__version__ = "2.2.1"

--- a/test_dependency_versions.py
+++ b/test_dependency_versions.py
@@ -53,10 +53,10 @@ if (
     or sv_version != citation_version
 ):
     fail(
-        f" emu_base {base_version}"
-        "or emu_sv {sv_version}"
-        "or emu_mps {mps_version}"
-        "do not match the citation version {citation_version}"
+        f" emu_base {base_version} "
+        f"or emu_sv {sv_version} "
+        f"or emu_mps {mps_version} "
+        f"do not match the citation version {citation_version}"
     )
 
 if mps_dep != base_version:


### PR DESCRIPTION
- bumped to version 2.2.1
- removed the validation step when creating an MPO from abstract representation. It is too strict, and a correct validation is already done by the base class.

This fixes the cicd, which started failing when pulser 1.5.4 came out.