### PR TITLE
dense operator validation

### DIFF
--- a/emu_sv/dense_operator.py
+++ b/emu_sv/dense_operator.py
@@ -1,6 +1,5 @@
 from __future__ import annotations
 
-import itertools
 from functools import reduce
 
 import torch
@@ -18,25 +17,6 @@ from pulser.backend.operator import FullOp, QuditOp
 from pulser.backend.state import Eigenstate
 
 dtype = torch.complex128
-
-
-def _validate_operator_targets(operations: FullOp, nqubits: int) -> None:
-    """Check for `operator_for_string` method"""
-    for tensorop in operations:
-        target_qids = (factor[1] for factor in tensorop[1])
-        target_qids_list = list(itertools.chain(*target_qids))
-        target_qids_set = set(target_qids_list)
-        if len(target_qids_set) < len(target_qids_list):
-            # Either the qubit id has been defined twice in an operation:
-            for qids in target_qids:
-                if len(set(qids)) < len(qids):
-                    raise ValueError("Duplicate atom ids in argument list.")
-            # Or it was defined in two different operations
-            raise ValueError("Each qubit can be targeted by only one operation.")
-        if max(target_qids_set) >= nqubits:
-            raise ValueError(
-                "The operation targets more qubits than there are in the register."
-            )
 
 
 class DenseOperator(Operator[complex, torch.Tensor, StateVector]):
@@ -149,7 +129,6 @@ class DenseOperator(Operator[complex, torch.Tensor, StateVector]):
             A DenseOperator instance corresponding to the given representation.
         """
 
-        _validate_operator_targets(operations, n_qudits)
         assert len(set(eigenstates)) == 2, "Only qubits are supported in EMU-SV."
 
         operators_with_tensors: dict[str, torch.Tensor | QuditOp] = dict()

--- a/test/emu_sv/test_dense_operator.py
+++ b/test/emu_sv/test_dense_operator.py
@@ -126,3 +126,22 @@ def test_applyto_expect_DenseOperator(zero: str, one: str) -> None:
     res = operator.expect(state_from_string)
     expected = state_torch.mH @ mult_state.T
     assert torch.isclose(res, expected)
+
+
+def test_wrong_basis_string_state():
+    operations = [
+        (
+            1.0,
+            [
+                ({"X": 2.0}, [0, 2]),
+                ({"Z": 3.0}, [1]),
+            ],
+        )
+    ]
+
+    with pytest.raises(ValueError) as ve:
+        DenseOperator.from_operator_repr(
+            eigenstates=("g", "1"), n_qudits=3, operations=operations
+        )
+    msg = "Every QuditOp key must be made up of two eigenstates among ('g', '1'); instead, got 'X'."
+    assert str(ve.value) == msg


### PR DESCRIPTION
the same fix as we just released for the `MPO` but for `DenseOperator`. I also added a test