### PR TITLE
[Emu-sv] measurement errors support 

### DIFF
--- a/emu_base/__init__.py
+++ b/emu_base/__init__.py
@@ -5,6 +5,7 @@ from .math.krylov_exp import krylov_exp, DEFAULT_MAX_KRYLOV_DIM
 from .jump_lindblad_operators import compute_noise_from_lindbladians
 from .math.matmul import matmul_2x2_with_batched
 from .aggregators import AggregationType, aggregate
+from.utils import apply_measurement_errors
 
 __all__ = [
     "__version__",
@@ -18,6 +19,7 @@ __all__ = [
     "HamiltonianType",
     "DEFAULT_MAX_KRYLOV_DIM",
     "DEVICE_COUNT",
+    apply_measurement_errors
 ]
 
 __version__ = "2.2.1"

--- a/emu_base/utils.py
+++ b/emu_base/utils.py
@@ -1,3 +1,5 @@
+from collections import Counter
+import random
 import torch
 
 
@@ -33,3 +35,39 @@ def deallocate_tensor(t: torch.Tensor) -> None:
     if t._base is not None:
         t._base.resize_(0)
         t._base.set_(source=replacement_storage)
+
+
+def readout_with_error(c: str, *, p_false_pos: float, p_false_neg: float) -> str:
+    # p_false_pos = false positive, p_false_neg = false negative
+    r = random.random()
+    if c == "0" and r < p_false_pos:
+        return "1"
+
+    if c == "1" and r < p_false_neg:
+        return "0"
+
+    return c
+
+
+def apply_measurement_errors(
+    bitstrings: Counter[str], *, p_false_pos: float, p_false_neg: float
+) -> Counter[str]:
+    """
+    Given a bag of sampled bitstrings, returns another bag of bitstrings
+    sampled with readout/measurement errors.
+
+        p_false_pos: probability of false positive
+        p_false_neg: probability of false negative
+    """
+
+    result: Counter[str] = Counter()
+    for bitstring, count in bitstrings.items():
+        for _ in range(count):
+            bitstring_with_error = "".join(
+                readout_with_error(c, p_false_pos=p_false_pos, p_false_neg=p_false_neg)
+                for c in bitstring
+            )
+
+            result[bitstring_with_error] += 1
+
+    return result

--- a/emu_mps/mps.py
+++ b/emu_mps/mps.py
@@ -7,11 +7,10 @@ from typing import List, Optional, Sequence, TypeVar, Mapping
 import torch
 
 from pulser.backend.state import State, Eigenstate
-from emu_base import DEVICE_COUNT
+from emu_base import DEVICE_COUNT, apply_measurement_errors
 from emu_mps import MPSConfig
 from emu_mps.algebra import add_factors, scale_factors
 from emu_mps.utils import (
-    apply_measurement_errors,
     assign_devices,
     truncate_impl,
     tensor_trace,

--- a/emu_mps/utils.py
+++ b/emu_mps/utils.py
@@ -210,41 +210,6 @@ def get_extended_site_index(
     raise ValueError(f"Index {desired_index} does not exist")
 
 
-def readout_with_error(c: str, *, p_false_pos: float, p_false_neg: float) -> str:
-    # p_false_pos = false positive, p_false_neg = false negative
-    r = random.random()
-    if c == "0" and r < p_false_pos:
-        return "1"
-
-    if c == "1" and r < p_false_neg:
-        return "0"
-
-    return c
-
-
-def apply_measurement_errors(
-    bitstrings: Counter[str], *, p_false_pos: float, p_false_neg: float
-) -> Counter[str]:
-    """
-    Given a bag of sampled bitstrings, returns another bag of bitstrings
-    sampled with readout/measurement errors.
-
-        p_false_pos: probability of false positive
-        p_false_neg: probability of false negative
-    """
-
-    result: Counter[str] = Counter()
-    for bitstring, count in bitstrings.items():
-        for _ in range(count):
-            bitstring_with_error = "".join(
-                readout_with_error(c, p_false_pos=p_false_pos, p_false_neg=p_false_neg)
-                for c in bitstring
-            )
-
-            result[bitstring_with_error] += 1
-
-    return result
-
 
 n_operator: torch.Tensor = torch.tensor(
     [

--- a/emu_sv/density_matrix_state.py
+++ b/emu_sv/density_matrix_state.py
@@ -4,7 +4,7 @@ import math
 from typing import Mapping, TypeVar, Type, Sequence
 import torch
 from pulser.backend import State
-from emu_base import DEVICE_COUNT
+from emu_base import DEVICE_COUNT,apply_measurement_errors
 from emu_sv.state_vector import StateVector
 from emu_sv.utils import index_to_bitstring
 from pulser.backend.state import Eigenstate
@@ -176,7 +176,6 @@ class DensityMatrix(State[complex, torch.Tensor]):
          Counter({'00': 517, '11': 483})
         """
 
-        assert p_false_neg == p_false_pos == 0.0, "Error rates must be 0.0"
 
         probabilities = torch.abs(self.matrix.diagonal())
 
@@ -187,6 +186,12 @@ class DensityMatrix(State[complex, torch.Tensor]):
             [index_to_bitstring(self.n_qudits, outcome) for outcome in outcomes]
         )
 
+        if p_false_neg > 0 or p_false_pos > 0:
+            counts = apply_measurement_errors(
+                counts,
+                p_false_pos=p_false_pos,
+                p_false_neg=p_false_neg,
+            )
         return counts
 
 

--- a/emu_sv/state_vector.py
+++ b/emu_sv/state_vector.py
@@ -8,7 +8,7 @@ import torch
 
 from emu_sv.utils import index_to_bitstring
 
-from emu_base import DEVICE_COUNT
+from emu_base import DEVICE_COUNT,apply_measurement_errors
 from pulser.backend import State
 from pulser.backend.state import Eigenstate
 
@@ -155,7 +155,6 @@ class StateVector(State[complex, torch.Tensor]):
         Returns:
             the measured bitstrings, by count
         """
-        assert p_false_neg == p_false_pos == 0.0, "Error rates must be 0.0"
 
         probabilities = torch.abs(self.vector) ** 2
 
@@ -166,7 +165,13 @@ class StateVector(State[complex, torch.Tensor]):
             [index_to_bitstring(self.n_qudits, outcome) for outcome in outcomes]
         )
 
-        # NOTE: false positives and negatives
+    
+        if p_false_neg > 0 or p_false_pos > 0:
+            counts = apply_measurement_errors(
+                counts,
+                p_false_pos=p_false_pos,
+                p_false_neg=p_false_neg,
+            )
         return counts
 
     def __add__(self, other: State) -> StateVector:

--- a/emu_sv/sv_config.py
+++ b/emu_sv/sv_config.py
@@ -106,9 +106,10 @@ class SVConfig(EmulationConfig):
                 "values of the NoiseModel are ignored!"
             )
         if "SPAM" in self.noise_model.noise_types:
-            raise NotImplementedError(
-                "SPAM errors are currently not supported in emu-sv."
-            )
+            if self.noise_model.state_prep_error != 0.0:
+                raise NotImplementedError(
+                    "State preparation errors are currently not supported in emu-sv."
+                )
 
     def _expected_kwargs(self) -> set[str]:
         return super()._expected_kwargs() | {
@@ -132,6 +133,10 @@ class SVConfig(EmulationConfig):
                     (
                         qubit_occupation_sv_impl
                         if self.noise_model.noise_types == ()
+                        or (
+                            self.noise_model.noise_types == ("SPAM",)
+                            and self.noise_model.state_prep_error == 0.0
+                        )
                         else qubit_occupation_sv_den_mat_impl
                     ),
                     obs_copy,
@@ -141,6 +146,10 @@ class SVConfig(EmulationConfig):
                     (
                         correlation_matrix_sv_impl
                         if self.noise_model.noise_types == ()
+                        or (
+                            self.noise_model.noise_types == ("SPAM",)
+                            and self.noise_model.state_prep_error == 0.0
+                        )
                         else correlation_matrix_sv_den_mat_impl
                     ),
                     obs_copy,
@@ -150,6 +159,10 @@ class SVConfig(EmulationConfig):
                     (
                         energy_variance_sv_impl
                         if self.noise_model.noise_types == ()
+                        or (
+                            self.noise_model.noise_types == ("SPAM",)
+                            and self.noise_model.state_prep_error == 0.0
+                        )
                         else energy_variance_sv_den_mat_impl
                     ),
                     obs_copy,
@@ -159,6 +172,10 @@ class SVConfig(EmulationConfig):
                     (
                         energy_second_moment_sv_impl
                         if self.noise_model.noise_types == ()
+                        or (
+                            self.noise_model.noise_types == ("SPAM",)
+                            and self.noise_model.state_prep_error == 0.0
+                        )
                         else energy_second_moment_den_mat_impl
                     ),
                     obs_copy,

--- a/test/emu_base/test_utils.py
+++ b/test/emu_base/test_utils.py
@@ -1,7 +1,11 @@
+from collections import Counter
+import random
+from unittest.mock import call, patch
+from requests import patch
 import torch
 import pytest
 from emu_base.utils import deallocate_tensor
-
+from emu_base.utils import readout_with_error, apply_measurement_errors
 
 def test_deallocate_tensor_shape():
     t = torch.ones(100, 100, dtype=torch.complex128)
@@ -111,3 +115,106 @@ def test_deallocate_tensordot():
     torch._C._cuda_clearCublasWorkspaces()  # tensordot allocates extra memory on first use
 
     assert torch.cuda.memory_allocated() == original_memory_allocated
+
+@patch("emu_base.utils.random.random")
+def test_readout_with_error(random_mock):
+    random_mock.side_effect = [0.6, 0.08, 0.4, 0.1, 0.04]
+
+    assert readout_with_error("0", p_false_pos=0.1, p_false_neg=0.2) == "0"
+    assert readout_with_error("0", p_false_pos=0.1, p_false_neg=0.2) == "1"
+    assert readout_with_error("1", p_false_pos=0.1, p_false_neg=0.2) == "1"
+    assert readout_with_error("1", p_false_pos=0.1, p_false_neg=0.2) == "0"
+    assert readout_with_error("0", p_false_pos=0.1, p_false_neg=0.2) == "1"
+
+def test_add_measurement_errors():
+    bitstrings = Counter(
+        {
+            "1010": 3,
+            "0101": 2,
+            "1111": 1,
+        }
+    )
+
+    # Error probability is null
+    bitstrings_without_measurement_errors = apply_measurement_errors(
+        bitstrings, p_false_pos=0.0, p_false_neg=0.0
+    )
+    assert bitstrings_without_measurement_errors == bitstrings
+
+    # Error probability is not null
+    p_false_pos = 0.1
+    p_false_neg = 0.2
+    with patch("emu_base.utils.readout_with_error") as readout_with_error_mock:
+        readout_with_error_mock.side_effect = [
+            "1",
+            "0",
+            "1",
+            "1",
+            "0",
+            "0",
+            "0",
+            "1",
+            "1",
+            "0",
+            "1",
+            "0",
+            "0",
+            "1",
+            "0",
+            "1",
+            "0",
+            "0",
+            "0",
+            "1",
+            "1",
+            "1",
+            "1",
+            "1",
+        ]
+
+        bitstrings_with_measurement_errors = apply_measurement_errors(
+            bitstrings, p_false_pos=p_false_pos, p_false_neg=p_false_neg
+        )
+
+        ps = {"p_false_pos": p_false_pos, "p_false_neg": p_false_neg}
+
+        # Counter is a subclass of dict.
+        # In Python 3.7+, dict iteration order is guaranteed to be the insertion order.
+        # Therefore, the loop in add_measurement_errors has a known order.
+
+        readout_with_error_mock.assert_has_calls(
+            [call("1", **ps), call("0", **ps), call("1", **ps), call("0", **ps)] * 3
+            + [call("0", **ps), call("1", **ps), call("0", **ps), call("1", **ps)] * 2
+            + [call("1", **ps), call("1", **ps), call("1", **ps), call("1", **ps)] * 1
+        )
+
+        assert bitstrings_with_measurement_errors == Counter(
+            {"1011": 1, "0001": 2, "1010": 1, "0101": 1, "1111": 1}
+        )
+
+
+def test_add_measurement_errors_large():
+    random.seed(0xDEADBEEF)
+
+    bitstrings = Counter(
+        {
+            "101010001": 39845,
+            "010110001": 2,
+            "111100001": 1,
+        }
+    )
+
+    bitstrings_with_measurement_errors = apply_measurement_errors(
+        bitstrings, p_false_pos=0.000001, p_false_neg=0.0000085
+    )
+    assert bitstrings_with_measurement_errors == Counter(
+        {
+            "101010001": 39843,
+            "101010000": 1,
+            "111010001": 1,
+            "010110001": 2,
+            "111100001": 1,
+        }
+    )
+
+    assert sum(bitstrings_with_measurement_errors.values()) == sum(bitstrings.values())

--- a/test/emu_mps/test_utils.py
+++ b/test/emu_mps/test_utils.py
@@ -1,127 +1,18 @@
 import math
-import random
-from collections import Counter
-from typing import List
-from unittest.mock import call, patch
 
+from typing import List
 import pytest
 import torch
 
 from emu_mps.utils import (
-    apply_measurement_errors,
     assign_devices,
     extended_mpo_factors,
     extended_mps_factors,
-    readout_with_error,
     split_tensor,
     get_extended_site_index,
     tensor_trace,
 )
 
-
-@patch("emu_mps.noise.random.random")
-def test_readout_with_error(random_mock):
-    random_mock.side_effect = [0.6, 0.08, 0.4, 0.1, 0.04]
-
-    assert readout_with_error("0", p_false_pos=0.1, p_false_neg=0.2) == "0"
-    assert readout_with_error("0", p_false_pos=0.1, p_false_neg=0.2) == "1"
-    assert readout_with_error("1", p_false_pos=0.1, p_false_neg=0.2) == "1"
-    assert readout_with_error("1", p_false_pos=0.1, p_false_neg=0.2) == "0"
-    assert readout_with_error("0", p_false_pos=0.1, p_false_neg=0.2) == "1"
-
-
-def test_add_measurement_errors():
-    bitstrings = Counter(
-        {
-            "1010": 3,
-            "0101": 2,
-            "1111": 1,
-        }
-    )
-
-    # Error probability is null
-    bitstrings_without_measurement_errors = apply_measurement_errors(
-        bitstrings, p_false_pos=0.0, p_false_neg=0.0
-    )
-    assert bitstrings_without_measurement_errors == bitstrings
-
-    # Error probability is not null
-    p_false_pos = 0.1
-    p_false_neg = 0.2
-    with patch("emu_mps.utils.readout_with_error") as readout_with_error_mock:
-        readout_with_error_mock.side_effect = [
-            "1",
-            "0",
-            "1",
-            "1",
-            "0",
-            "0",
-            "0",
-            "1",
-            "1",
-            "0",
-            "1",
-            "0",
-            "0",
-            "1",
-            "0",
-            "1",
-            "0",
-            "0",
-            "0",
-            "1",
-            "1",
-            "1",
-            "1",
-            "1",
-        ]
-
-        bitstrings_with_measurement_errors = apply_measurement_errors(
-            bitstrings, p_false_pos=p_false_pos, p_false_neg=p_false_neg
-        )
-
-        ps = {"p_false_pos": p_false_pos, "p_false_neg": p_false_neg}
-
-        # Counter is a subclass of dict.
-        # In Python 3.7+, dict iteration order is guaranteed to be the insertion order.
-        # Therefore, the loop in add_measurement_errors has a known order.
-
-        readout_with_error_mock.assert_has_calls(
-            [call("1", **ps), call("0", **ps), call("1", **ps), call("0", **ps)] * 3
-            + [call("0", **ps), call("1", **ps), call("0", **ps), call("1", **ps)] * 2
-            + [call("1", **ps), call("1", **ps), call("1", **ps), call("1", **ps)] * 1
-        )
-
-        assert bitstrings_with_measurement_errors == Counter(
-            {"1011": 1, "0001": 2, "1010": 1, "0101": 1, "1111": 1}
-        )
-
-
-def test_add_measurement_errors_large():
-    random.seed(0xDEADBEEF)
-
-    bitstrings = Counter(
-        {
-            "101010001": 39845,
-            "010110001": 2,
-            "111100001": 1,
-        }
-    )
-
-    bitstrings_with_measurement_errors = apply_measurement_errors(
-        bitstrings, p_false_pos=0.000001, p_false_neg=0.0000085
-    )
-    assert bitstrings_with_measurement_errors == Counter(
-        {
-            "101010001": 39843,
-            "101010000": 1,
-            "111010001": 1,
-            "010110001": 2,
-            "111100001": 1,
-        }
-    )
-
-    assert sum(bitstrings_with_measurement_errors.values()) == sum(bitstrings.values())
 
 
 @pytest.mark.parametrize(

--- a/test/emu_sv/test_end_to_end.py
+++ b/test/emu_sv/test_end_to_end.py
@@ -1,5 +1,6 @@
 import math
 import random
+from unittest.mock import ANY, MagicMock, patch
 import pytest
 import torch
 from pytest import approx
@@ -76,6 +77,7 @@ def simulate(
     given_fidelity_state: bool = True,
     interaction_cutoff: float = 0,
     gpu: bool = True,
+    num_shots: int = 1000,
 ) -> Results:
     n_qubits = len(seq.register.qubit_ids)
     if noise_model is None:
@@ -84,10 +86,10 @@ def simulate(
     if given_fidelity_state:
         fidelity_state = create_antiferromagnetic_state_vector(n_qubits, gpu=gpu)
     else:
-        fidelity_state = StateVector.make(n_qubits)  # make |00.0>
+        fidelity_state = StateVector.make(n_qubits, gpu=gpu)  # make |00.0>
 
     if state_prep_error > 0.0 or p_false_pos > 0.0 or p_false_neg > 0.0:
-        assert noise_model is None, "Provide either noise_model or SPAM values"
+        # assert noise_model is None, "Provide either noise_model or SPAM values"
 
         runs_args = (
             {"runs": 1, "samples_per_run": 1} if state_prep_error > 0.0 else {}
@@ -107,7 +109,7 @@ def simulate(
         krylov_tolerance=1e-5,
         observables=[
             StateResult(evaluation_times=times),
-            BitStrings(evaluation_times=times, num_shots=1000),
+            BitStrings(evaluation_times=times, num_shots=num_shots),
             Fidelity(evaluation_times=times, state=fidelity_state, tag_suffix="1"),
             Occupation(evaluation_times=times),
             Energy(evaluation_times=times),
@@ -148,7 +150,7 @@ def simulate_with_den_matrix(
         fidelity_state = DensityMatrix.make(n_qubits)  # make |00.0>
 
     if state_prep_error > 0.0 or p_false_pos > 0.0 or p_false_neg > 0.0:
-        assert noise_model is None, "Provide either noise_model or SPAM values"
+        assert noise_model is not None, "Provide either noise_model or SPAM values"
 
     times = [1.0]
     sv_config = SVConfig(
@@ -229,7 +231,7 @@ def test_end_to_end_afm_ring() -> None:
     )
 
 
-def test_end_to_end_afm_ring_with_noise() -> None:
+def test_end_to_end_afm_ring_with_effective_noise() -> None:
     torch.manual_seed(seed)
 
     num_qubits = 6
@@ -242,7 +244,6 @@ def test_end_to_end_afm_ring_with_noise() -> None:
         t_rise=t_rise,
         t_fall=t_fall,
     )
-
     noise_model = pulser.noise_model.NoiseModel(
         depolarizing_rate=0.1,
         dephasing_rate=0.1,
@@ -506,3 +507,87 @@ def test_end_to_end_spontaneous_emission_rate() -> None:
         device=device,
     )
     assert torch.allclose(result.state[-1].matrix, expected_state, atol=1e-4)
+
+
+def test_end_to_end_1D_sv_spam() -> None:
+    torch.manual_seed(seed)
+    random.seed(seed)
+    num_qubits = 4
+
+    # initial state with all atoms in |g> state
+    reg = pulser.Register.rectangle(num_qubits, 1, spacing=10, prefix="q")
+    pulse = pulser.Pulse.ConstantPulse(1000, 0.0, 0.0, 0.0)
+
+    seq = pulser.Sequence(reg, pulser.MockDevice)
+    seq.declare_channel("ising_global", "rydberg_global")
+    seq.add(pulse, "ising_global")
+    # false positive readout error
+    result = simulate(
+        seq,
+        gpu=gpu,
+        p_false_neg=0.0,
+        p_false_pos=0.1,
+        num_shots=10000,
+        given_fidelity_state=False,
+    )  # only run on cpu, bitstring sampling is device dependent
+
+    final_time = -1  # seq.get_duration()
+    bitstrings = result.bitstrings[final_time]
+
+    assert bitstrings["1" * int(num_qubits)] == 1
+    assert bitstrings["0" * int(num_qubits)] == 6534
+    assert bitstrings["1000"] == 747
+    assert bitstrings["0100"] == 719
+    assert bitstrings["0010"] == 734
+    assert bitstrings["0001"] == 732
+
+    # initial state with all atoms in |r> state
+    eigenstate = ("r", "g")
+    amplitudes = {"r" * num_qubits: 1.0}
+    initial_state = StateVector.from_state_amplitudes(
+        eigenstates=eigenstate, amplitudes=amplitudes
+    )
+    # false negative readout error
+    result = simulate(
+        seq,
+        gpu=gpu,
+        initial_state=initial_state,
+        p_false_neg=0.1,
+        p_false_pos=0.0,
+        num_shots=10000,
+        given_fidelity_state=False,
+    )
+
+    final_time = -1
+    bitstrings = result.bitstrings[final_time]
+
+    assert bitstrings["1" * int(num_qubits)] == 6589
+    assert bitstrings["0" * int(num_qubits)] == 1
+    assert bitstrings["1110"] == 724
+    assert bitstrings["1101"] == 766
+    assert bitstrings["1011"] == 725
+    assert bitstrings["0111"] == 725
+
+
+def test_end_to_end_afm_line_with_measurement_errors() -> None:
+    torch.manual_seed(seed)
+    random.seed(seed)
+    num_qubits = 4
+
+    reg = pulser.Register.rectangle(num_qubits, 1, spacing=10, prefix="q")
+    pulse = pulser.Pulse.ConstantPulse(1000, 0.0, 0.0, 0.0)
+
+    seq = pulser.Sequence(reg, pulser.MockDevice)
+    seq.declare_channel("ising_global", "rydberg_global")
+    seq.add(pulse, "ising_global")
+    with patch(
+        "emu_sv.state_vector.apply_measurement_errors"
+    ) as apply_measurement_errors_mock:
+        bitstrings = MagicMock()
+        apply_measurement_errors_mock.return_value = bitstrings
+
+        results = simulate(seq, p_false_pos=0.0, p_false_neg=0.5)
+        apply_measurement_errors_mock.assert_called_with(
+            ANY, p_false_pos=0.0, p_false_neg=0.5
+        )
+        assert results.bitstrings[-1] is bitstrings

--- a/test/emu_sv/test_svconfig.py
+++ b/test/emu_sv/test_svconfig.py
@@ -54,7 +54,7 @@ def test_unsupported_noise() -> None:
                 hyperfine_dephasing_rate=1.5,
             )
         )
-    assert str(exc.value) == "SPAM errors are currently not supported in emu-sv."
+    assert str(exc.value) == "State preparation errors are currently not supported in emu-sv."
 
 
 def test_default_SVConfig_ctr() -> None:


### PR DESCRIPTION
- Measurement errors support in case of density matrix and state vector
- Measurement errors were implemented in emu-mps. The code is moved to `emu_base` in order to be accepted by the other states.
- Added some tests regarding false positives and negatives