### PR TITLE
[emu-base] fix evaluation times in pulser adapter with hardware modulation

### DIFF
--- a/CITATION.cff
+++ b/CITATION.cff
@@ -39,5 +39,5 @@ abstract: >-
 keywords:
   - analog quantum computing
   - emulation
-version: 2.2.1
+version: 2.2.2
 date-released: '2025-05-12'

--- a/ci/emu_mps/pyproject.toml
+++ b/ci/emu_mps/pyproject.toml
@@ -23,7 +23,7 @@ classifiers=[
 ]
 dynamic = ["version"]
 dependencies = [
-  "emu-base==2.2.1"]
+  "emu-base==2.2.2"]
 
 [project.urls]
 Documentation = "https://pasqal-io.github.io/emulators/"

--- a/ci/emu_sv/pyproject.toml
+++ b/ci/emu_sv/pyproject.toml
@@ -23,7 +23,7 @@ classifiers=[
 ]
 dynamic = ["version"]
 dependencies = [
-  "emu-base==2.2.1"]
+  "emu-base==2.2.2"]
 
 [project.urls]
 Documentation = "https://pasqal-io.github.io/emulators/"

--- a/emu_base/__init__.py
+++ b/emu_base/__init__.py
@@ -20,4 +20,4 @@ __all__ = [
     "DEVICE_COUNT",
 ]
 
-__version__ = "2.2.1"
+__version__ = "2.2.2"

--- a/emu_base/pulser_adapter.py
+++ b/emu_base/pulser_adapter.py
@@ -303,7 +303,7 @@ def _get_target_times(
     observable_times.add(sequence_duration)
     for obs in config.observables:
         times: Sequence[float]
-        if obs.evaluation_times:
+        if obs.evaluation_times is not None:
             times = obs.evaluation_times
         elif config.default_evaluation_times != "Full":
             times = config.default_evaluation_times.tolist()  # type: ignore[union-attr,assignment]

--- a/emu_base/pulser_adapter.py
+++ b/emu_base/pulser_adapter.py
@@ -308,10 +308,12 @@ class PulserData:
     def __init__(self, *, sequence: pulser.Sequence, config: EmulationConfig, dt: int):
         self.qubit_ids = sequence.register.qubit_ids
         self.qubit_count = len(self.qubit_ids)
-        sequence_duration = sequence.get_duration()
+        sequence_duration = sequence.get_duration(
+            include_fall_time=config.with_modulation
+        )
         # the end value is exclusive, so add +1
-        observable_times = set(torch.arange(0, sequence.get_duration() + 1, dt).tolist())
-        observable_times.add(sequence.get_duration())
+        observable_times = set(range(0, sequence_duration + 1, dt))
+        observable_times.add(sequence_duration)
         for obs in config.observables:
             times: Sequence[float]
             if obs.evaluation_times is not None:

--- a/emu_mps/__init__.py
+++ b/emu_mps/__init__.py
@@ -37,4 +37,4 @@ __all__ = [
     "EntanglementEntropy",
 ]
 
-__version__ = "2.2.1"
+__version__ = "2.2.2"

--- a/emu_sv/__init__.py
+++ b/emu_sv/__init__.py
@@ -38,4 +38,4 @@ __all__ = [
     "DensityMatrix",
 ]
 
-__version__ = "2.2.1"
+__version__ = "2.2.2"

--- a/test/emu_base/test_adapter.py
+++ b/test/emu_base/test_adapter.py
@@ -32,6 +32,8 @@ sequence.register.qubits = {
     for i, key in enumerate(TEST_QUBIT_IDS)
 }
 
+mock_observable = MagicMock(spec=Observable, evaluation_times=None)
+
 expected_amp_factors = {
     0: torch.tensor([1.5, 1.0, 0.4]),
     1: torch.tensor([1.5, 1.0, 0.4]),
@@ -937,6 +939,7 @@ def test_parsed_sequence(mock_pulser_sample):
     ops = _get_all_lindblad_noise_operators(noise_model)
 
     config = EmulationConfig(
+        observables=[mock_observable],
         noise_model=noise_model,
         interaction_matrix=interaction_matrix,
         interaction_cutoff=0.15,
@@ -1026,6 +1029,7 @@ def test_laser_waist(mock_pulser_sample, mock_qubit_positions):
     )
 
     config = EmulationConfig(
+        observables=[mock_observable],
         noise_model=noise_model,
         interaction_matrix=interaction_matrix,
         interaction_cutoff=0.15,
@@ -1088,6 +1092,7 @@ def test_supported_noise_types(
     )
 
     config = EmulationConfig(
+        observables=[mock_observable],
         noise_model=noise_model,
         interaction_matrix=interaction_matrix,
         interaction_cutoff=0.15,


### PR DESCRIPTION
Resolve #144 

From the issue

> Current implementation of `PulserData` constructor in `emu_base/pulser_adapter.py` incorrectly compute the global observable times.
The issue is that when calling `sequence.get_duration()` one should add the kwarg `include_fall_times=config.with_modulation` to capture the extended duration of the sequence due to hardware modulation.

```python
class PulserData:
    ...

    def __init__(self, *, sequence: pulser.Sequence, config: EmulationConfig, dt: int):
        self.qubit_ids = sequence.register.qubit_ids
        self.qubit_count = len(self.qubit_ids)
        sequence_duration = sequence.get_duration()
        # the end value is exclusive, so add +1
        observable_times = set(torch.arange(0, sequence.get_duration() + 1, dt).tolist())
        observable_times.add(sequence.get_duration())
        for obs in config.observables:
            ...
```
>### Acceptance criteria
>fix and test that the `observable_times` are computed correctly with a sequence with hardware modulation.



### Changes

1. evaluation times are now computed, including the extra time for hardware modulation
2. refactor `_get_target_times`
3. fix warnings empty observables in tests
4. integration test with_modulation
5. small additional test on evaluation times 

### Outcome

Running the following script
 ```python
import pulser
import numpy as np
import emu_mps


# construct sequence
seq = pulser.Sequence(pulser.Register({"q0": (-5, 0), "q1": (5, 0)}), pulser.AnalogDevice)
seq.declare_channel("rydberg_global", "rydberg_global")
t = seq.declare_variable("t", dtype=int)
amp_wf = pulser.BlackmanWaveform(t, np.pi)
det_wf = pulser.RampWaveform(t, -5, 5)
seq.add(pulser.Pulse(amp_wf, det_wf, 0), "rydberg_global")
duration = 1000
built_seq = seq.build(t=duration)

# simulation params
evaluation_times = np.linspace(0,1,101).tolist()
occupation = pulser.backend.Occupation(evaluation_times=evaluation_times, one_state="r")


# build Qutip backend
config = pulser.backend.EmulationConfig(
    with_modulation=True,  # modulation
    observables=[occupation]
)
qutip_bknd = pulser.backends.QutipBackendV2(built_seq, config=config)


# build emu-mps backend
mpsconfig = emu_mps.MPSConfig(
    with_modulation=True,  # modulation
    observables=[occupation],
    log_level=2000,
)
mps_bknd = emu_mps.MPSBackend(built_seq, config=mpsconfig)


# run simulations
qutip_results = qutip_bknd.run()
mps_results = mps_bknd.run()

# extract occupation from results
qutip_eval_times = qutip_results.get_result_times(occupation)
qutip_occupation = np.array([occ for occ in qutip_results.occupation])
mps_eval_times = mps_results.get_result_times(occupation)
mps_occupation = np.array([occ for occ in mps_results.occupation])

import matplotlib.pyplot as plt

fig, ax = plt.subplots(1, 1, dpi = 200)
ax.plot(mps_eval_times, mps_occupation[:,0], label = "emu-mps")
ax.plot(qutip_eval_times, qutip_occupation[:,0], label = "qutip-backend v2", ls="dashed")
ax.set_xlabel("t")
ax.set_ylabel("Population of chosen basis state")
ax.grid(True)
ax.legend()
```

*Before* vs *After*

<img src="https://github.com/user-attachments/assets/fc8bea47-08e0-4e71-9ff2-03a5fac97ae4" width="47%">
<img src="https://github.com/user-attachments/assets/ccadeaab-ea95-42c2-ab56-35cc66b6f03a" width="47%">




