### PR TITLE
DMRGBackend implementation class

### DIFF
--- a/emu_mps/mps_backend_impl.py
+++ b/emu_mps/mps_backend_impl.py
@@ -366,7 +366,7 @@ class MPSBackendImpl:
             else:
                 self._evolve(0, 1, dt=delta_time, orth_center_right=False)
 
-            self.tdvp_complete()
+            self.sweep_complete()
 
         elif (
             self.tdvp_index < self.qubit_count - 2
@@ -431,7 +431,7 @@ class MPSBackendImpl:
             self.tdvp_index -= 1
 
             if self.tdvp_index == 0:
-                self.tdvp_complete()
+                self.sweep_complete()
                 self.swipe_direction = SwipeDirection.LEFT_TO_RIGHT
 
         else:
@@ -439,7 +439,7 @@ class MPSBackendImpl:
 
         self.save_simulation()
 
-    def tdvp_complete(self) -> None:
+    def sweep_complete(self) -> None:
         self.current_time = self.target_time
         self.timestep_complete()
 
@@ -624,7 +624,7 @@ class NoisyMPSBackendImpl(MPSBackendImpl):
         super().init()
         self.set_jump_threshold(1.0)
 
-    def tdvp_complete(self) -> None:
+    def sweep_complete(self) -> None:
         previous_time = self.current_time
         self.current_time = self.target_time
         previous_norm_gap_before_jump = self.norm_gap_before_jump
@@ -769,9 +769,9 @@ class DMRGBackend(MPSBackendImpl):
             if self.state.orthogonality_center == 0:
                 self.direction = SwipeDirection.LEFT_TO_RIGHT
                 self.sweep_count += 1
-                self.tdvp_complete()
+                self.sweep_complete()
 
-    def tdvp_complete(self) -> None:
+    def sweep_complete(self) -> None:
         # This marks the end of one full sweep: checking convergence
         if self.convergence_check(self.energy_tolerance):
             self.timestep_complete()

--- a/emu_mps/mps_backend_impl.py
+++ b/emu_mps/mps_backend_impl.py
@@ -32,6 +32,7 @@ import emu_mps.optimatrix as optimat
 from emu_mps.solver_utils import (
     evolve_pair,
     evolve_single,
+    minimize_energy_pair,
     new_right_bath,
     right_baths,
 )
@@ -688,6 +689,128 @@ class NoisyMPSBackendImpl(MPSBackendImpl):
         )
 
         super().fill_results()
+
+
+class DMRGBackend(MPSBackendImpl):
+    """
+    Implementing the DMRG algorithm for the computation of the ground state
+    at different time steps
+    The algorithm relies on the sweeping (back and forth) procedure
+    This procedure locally minimizes the 2-site problem using the Lanczos algorithm
+    """
+
+    def __init__(self, mps_config: MPSConfig, pulser_data: PulserData):
+        super().__init__(mps_config, pulser_data)
+
+    def convergence_check(
+        self,
+        previous_energy: Optional[float],
+        current_energy: Optional[float],
+        energy_tolerance: float,
+    ) -> bool:
+        """
+        Check convergence by comparing energy of two successive full sweeps.
+        Returns True if the absolute difference is below tol.
+        """
+        if previous_energy is None or current_energy is None:
+            return False
+
+        energy_diff = abs(current_energy - previous_energy)
+        return energy_diff < energy_tolerance
+
+    def run_dmrg(self, num_sweeps: int = 20, energy_tolerance: float = 1e-5) -> None:
+        """
+        Perform a single DMRG ground state search
+        """
+        self.init()  # to initiate the ham, baths etc.
+        mps_size = len(self.state.factors)
+        if mps_size < 2:
+            raise TypeError("DMRG algorithm requires an MPS of at least 2 sites")
+
+        self.state.orthogonality_center = 0
+        direction = SwipeDirection.LEFT_TO_RIGHT
+
+        previous_energy = None
+        current_energy = None
+        converged = False
+
+        for sweep in range(1, num_sweeps + 1):
+            # for each sweep, there are 2(mps_size - 1) neihbouring bonds
+            for step in range(2 * (mps_size - 1)):
+                print(f"sweep: {sweep}. step: {step}/{2*(mps_size-1)}")
+                ortho_center = self.state.orthogonality_center
+
+                # determine bond indices
+                if mps_size == 2:
+                    idx_Left, idx_Right = 0, 1
+                elif direction == SwipeDirection.LEFT_TO_RIGHT:
+                    idx_Left, idx_Right = ortho_center, ortho_center + 1
+                elif direction == SwipeDirection.RIGHT_TO_LEFT:
+                    idx_Left, idx_Right = ortho_center - 1, ortho_center
+
+                left_site = self.state.factors[idx_Left]
+                right_site = self.state.factors[idx_Right]
+                left_bath = self.left_baths[-1]
+                right_bath = self.right_baths[-1]
+                left_ham = self.hamiltonian.factors[idx_Left]
+                right_ham = self.hamiltonian.factors[idx_Right]
+
+                # Minimize Hamiltonian on this two-site block
+                new_node_left, new_node_right, current_energy = minimize_energy_pair(
+                    state_factors=(left_site, right_site),
+                    ham_factors=(left_ham, right_ham),
+                    baths=(left_bath, right_bath),
+                    orth_center_right=(direction == SwipeDirection.LEFT_TO_RIGHT),
+                    config=self.config,
+                    residual_tolerance=1e-7,
+                )
+
+                # Update MPS factors with updated mps tensors
+                self.state.factors[idx_Left] = new_node_left
+                self.state.factors[idx_Right] = new_node_right
+
+                # Update baths and sweep
+                if direction == SwipeDirection.LEFT_TO_RIGHT:
+                    update_left_bath = new_left_bath(
+                        self.get_current_left_bath(),
+                        self.state.factors[idx_Left],
+                        self.hamiltonian.factors[idx_Right],
+                    ).to(self.state.factors[idx_Right].device)
+                    self.left_baths.append(update_left_bath)
+                    self.right_baths.pop()
+
+                    self.state.orthogonality_center += 1
+                else:
+                    # Append new right bath, then pop left
+                    update_right_bath = new_right_bath(
+                        self.get_current_right_bath(),
+                        self.state.factors[idx_Right],
+                        self.hamiltonian.factors[idx_Right],
+                    ).to(self.state.factors[idx_Left].device)
+                    self.right_baths.append(update_right_bath)
+                    self.left_baths.pop()
+
+                    self.state.orthogonality_center -= 1
+
+                if (
+                    self.state.orthogonality_center == mps_size - 1
+                    and direction == SwipeDirection.LEFT_TO_RIGHT
+                ):
+                    assert step == mps_size - 2
+                    direction = SwipeDirection.RIGHT_TO_LEFT
+                elif (
+                    self.state.orthogonality_center == 0
+                    and direction == SwipeDirection.RIGHT_TO_LEFT
+                ):
+                    direction = SwipeDirection.LEFT_TO_RIGHT
+
+            # end of one full sweep
+            if self.convergence_check(previous_energy, current_energy, energy_tolerance):
+                converged = True
+                break
+            previous_energy = current_energy
+        if not converged:
+            raise RuntimeError(f"DMRG failed to converge after {num_sweeps} sweeps")
 
 
 def create_impl(sequence: Sequence, config: MPSConfig) -> MPSBackendImpl:

--- a/emu_mps/solver_utils.py
+++ b/emu_mps/solver_utils.py
@@ -229,9 +229,9 @@ def evolve_single(
 
 def minimize_energy_pair(
     *,
-    state_factors: tuple[torch.Tensor],
+    state_factors: Sequence[torch.Tensor],
     baths: tuple[torch.Tensor, torch.Tensor],
-    ham_factors: tuple[torch.Tensor],
+    ham_factors: Sequence[torch.Tensor],
     orth_center_right: bool,
     config: MPSConfig,
     residual_tolerance: float,


### PR DESCRIPTION
## summary of updates done in this PR

- **introduce a `DMRGBackend` class**  
  - Inherits from `MPSBackendImpl` (reuses state factors, Hamiltonian factors, left/right baths, etc.)  
  - Implements two‑site energy minimization sweeps via `minimize_energy_pair`
  - checks the convergence of the energy at the end of a full sweep 

- **Integration in current emu_mps API design**  
  - Overrides `progress()` to perform one DMRG step at a time  
  - Renames the end‑of‑sweep pattern from `tdvp_complete()` → `sweep_complete()`  
 
---

## Remaining tasks 

- [ ] Write a test for the `DMRGBackend` class

---

## Follow‑up work (next PR)

1. Add an enum flag in the config (`dmrg` vs. `tdvp`)  
2. Update `create_impl()`   
3. Write an end‑to‑end test to simulate a realistic pulse sequence
