### PR TITLE
updating emu-sv doc

### DIFF
--- a/docs/emu_sv/index.md
+++ b/docs/emu_sv/index.md
@@ -1,6 +1,6 @@
 # Welcome to emu-sv
 
-You have found the documentation for emu-sv. The emulator **emu-sv** is a backend for the [Pulser low-level Quantum Programming toolkit](https://pulser.readthedocs.io) that lets you run quantum algorithms on a simulated device, using GPU acceleration if available. More in depth, emu-sv is designed to **emu**late the dynamics of programmable arrays of neutral atoms, using the **s**tate **v**ector representation. While benchmarking is incomplete as of this writing, early results suggest that emu-sv is faster and more accurate than tensor-network based emulators up to ~25 qubits.
+You have found the documentation for emu-sv. The emulator **emu-sv** is a backend for the [Pulser low-level Quantum Programming toolkit](https://pulser.readthedocs.io) that lets you run quantum algorithms on a simulated device, using GPU acceleration if available. More in depth, emu-sv is designed to **emu**late the dynamics of programmable arrays of neutral atoms, using the **s**tate **v**ector representation. While benchmarking is incomplete as of this writing, early results suggest that emu-sv is faster and more accurate than tensor-network based emulators up to ~27 qubits.
 
 ## Supported features
 

--- a/docs/emu_sv/index.md
+++ b/docs/emu_sv/index.md
@@ -1,6 +1,6 @@
 # Welcome to emu-sv
 
-You have found the documentation for emu-sv. The emulator **emu-sv** is a backend for the [Pulser low-level Quantum Programming toolkit](https://pulser.readthedocs.io) that lets you run quantum algorithms on a simulated device, using GPU acceleration if available. More in depth, emu-sv is designed to **emu**late the dynamics of programmable arrays of neutral atoms, using the **s**tate **v**ector representation. While benchmarking is incomplete as of this writing, early results suggest that emu-sv is faster and more accurate than tensor-network based emulators up to ~20 qubits.
+You have found the documentation for emu-sv. The emulator **emu-sv** is a backend for the [Pulser low-level Quantum Programming toolkit](https://pulser.readthedocs.io) that lets you run quantum algorithms on a simulated device, using GPU acceleration if available. More in depth, emu-sv is designed to **emu**late the dynamics of programmable arrays of neutral atoms, using the **s**tate **v**ector representation. While benchmarking is incomplete as of this writing, early results suggest that emu-sv is faster and more accurate than tensor-network based emulators up to ~25 qubits.
 
 ## Supported features
 

--- a/docs/emu_sv/index.md
+++ b/docs/emu_sv/index.md
@@ -1,6 +1,6 @@
 # Welcome to emu-sv
 
-You have found the documentation for emu-sv. The emulator **emu-sv** is a backend for the [Pulser low-level Quantum Programming toolkit](https://pulser.readthedocs.io) that lets you run quantum algorithms on a simulated device, using GPU acceleration if available. More in depth, emu-sv is designed to **emu**late the dynamics of programmable arrays of neutral atoms, using the **s**tate **v**ector representation. While benchmarking is incomplete as of this writing, early results suggest that emu-sv is faster and more accurate than tensor-network based emulators up to ~27 qubits.
+You have found the documentation for emu-sv. The emulator **emu-sv** is a backend for the [Pulser low-level Quantum Programming toolkit](https://pulser.readthedocs.io) that lets you run quantum algorithms on a simulated device, using GPU acceleration if available. More in depth, emu-sv is designed to **emu**late the dynamics of programmable arrays of neutral atoms, using the **s**tate **v**ector representation. Our benchmarks indicate that on the gpu emu-sv is both faster and more accurate than emu-mps wherever a simulation fits in memory. For typical sequences this means up to ~27 qubits.
 
 ## Supported features
 


### PR DESCRIPTION
`emu-sv` emulator should be able to run simulations up to 27 qubits on the GPU, since it requires less than 20 GB to run a 26 qubit sequence.