### PR TITLE
preserve state norm after truncation

### DIFF
--- a/CITATION.cff
+++ b/CITATION.cff
@@ -39,5 +39,5 @@ abstract: >-
 keywords:
   - analog quantum computing
   - emulation
-version: 2.4.2
+version: 2.4.3
 date-released: '2025-05-12'

--- a/ci/emu_mps/pyproject.toml
+++ b/ci/emu_mps/pyproject.toml
@@ -23,7 +23,7 @@ classifiers=[
 ]
 dynamic = ["version"]
 dependencies = [
-  "emu-base==2.4.2"]
+  "emu-base==2.4.3"]
 
 [project.urls]
 Documentation = "https://pasqal-io.github.io/emulators/"

--- a/ci/emu_sv/pyproject.toml
+++ b/ci/emu_sv/pyproject.toml
@@ -23,7 +23,7 @@ classifiers=[
 ]
 dynamic = ["version"]
 dependencies = [
-  "emu-base==2.4.2"]
+  "emu-base==2.4.3"]
 
 [project.urls]
 Documentation = "https://pasqal-io.github.io/emulators/"

--- a/emu_base/__init__.py
+++ b/emu_base/__init__.py
@@ -21,4 +21,4 @@ __all__ = [
     "unix_like",
 ]
 
-__version__ = "2.4.2"
+__version__ = "2.4.3"

--- a/emu_mps/__init__.py
+++ b/emu_mps/__init__.py
@@ -36,4 +36,4 @@ __all__ = [
     "EntanglementEntropy",
 ]
 
-__version__ = "2.4.2"
+__version__ = "2.4.3"

--- a/emu_mps/solver_utils.py
+++ b/emu_mps/solver_utils.py
@@ -5,7 +5,7 @@ from emu_base import krylov_exp
 from emu_base.math.krylov_energy_min import krylov_energy_minimization
 from emu_base.utils import deallocate_tensor
 from emu_mps import MPS, MPO
-from emu_mps.utils import split_tensor
+from emu_mps.utils import split_matrix
 from emu_mps.mps_config import MPSConfig
 
 
@@ -178,11 +178,12 @@ def evolve_pair(
         is_hermitian=is_hermitian,
     ).view(left_bond_dim * 2, 2 * right_bond_dim)
 
-    l, r = split_tensor(
+    l, r = split_matrix(
         evol,
         max_error=config.precision,
         max_rank=config.max_bond_dim,
         orth_center_right=orth_center_right,
+        preserve_norm=not is_hermitian,  # only relevant for computing jump times
     )
 
     return l.view(left_bond_dim, 2, -1), r.view(-1, 2, right_bond_dim).to(right_device)
@@ -262,7 +263,7 @@ def minimize_energy_pair(
     )
     updated_state = updated_state.view(left_bond_dim * 2, 2 * right_bond_dim)
 
-    l, r = split_tensor(
+    l, r = split_matrix(
         updated_state,
         max_error=config.precision,
         max_rank=config.max_bond_dim,

--- a/emu_sv/__init__.py
+++ b/emu_sv/__init__.py
@@ -38,4 +38,4 @@ __all__ = [
     "DensityMatrix",
 ]
 
-__version__ = "2.4.2"
+__version__ = "2.4.3"


### PR DESCRIPTION
When the Hamiltonian is not Hermitian in emu-mps (i.e. when doing Lindblad noise monte carlo style), the norm of the state will decay for two reasons during time evolution:
- the Hamiltonian is not Hermitian
- truncation

The last effect becomes significant when `max_bond_dim` is hit, and can cause collapse times to be computed incorrectly. In this case, do a little extra work to rescale the truncated matrices back to the old norm.
I noticed that the relevant function, `split_tensor` is only implemented for matrices, so I renamed it to `split_matrix`.  If you look in the usage, the input tensor is always reshaped into the appropriate matrix before hand, and then reshaped again afterwards.