### PR TITLE
fix log level

### DIFF
--- a/emu_base/utils.py
+++ b/emu_base/utils.py
@@ -34,6 +34,7 @@ def init_logging(log_level: int, log_file: Path | None) -> logging.Logger:
     """
     logger = logging.getLogger("emulators")
     logger.propagate = False
+    logger.setLevel(logging.DEBUG)
 
     handler: logging.Handler
     if log_file is None:


### PR DESCRIPTION
I was using the `logging.Handler` to specify the log level, but it seems the log level of the `logging.Logger` acts as a first gate, and only then is it passed to the handlers. The default log level of `logging.Logger` is `logging.WARNING` which obviously blocks all the info about runtime and such. I thought I tested this thoroughly when I changed it, but apparently not.