### PR TITLE
fix typo in ci/emu_base/pyproject.toml

### DIFF
--- a/ci/emu_base/pyproject.toml
+++ b/ci/emu_base/pyproject.toml
@@ -22,7 +22,7 @@ classifiers=[
     "Programming Language :: Python :: Implementation :: PyPy",
 ]
 dependencies = [
-  "pulser-core[torch]>=1.7.0rc2", "torch>=2.9.0]
+  "pulser-core[torch]>=1.7.0rc2", "torch>=2.9.0"]
 dynamic = ["version"]
 
 [project.urls]


### PR DESCRIPTION
The release process is failing, because emu-base fails to build due to the typo.