### PR TITLE
TDVP small refactor

### DIFF
--- a/emu_mps/mps_backend_impl.py
+++ b/emu_mps/mps_backend_impl.py
@@ -105,7 +105,7 @@ class MPSBackendImpl:
     right_baths: list[torch.Tensor]
     target_time: float
     results: Results
-    _swipe_direction: SwipeDirection
+    _swipe_direction: SwipeDirection = SwipeDirection.LEFT_TO_RIGHT
     _sweep_index: int = 0
     _timestep_index: int = 0
 
@@ -139,7 +139,6 @@ class MPSBackendImpl:
 
         self.hamiltonian_type = pulser_data.hamiltonian_type
         self.time = time.time()
-        self._swipe_direction = SwipeDirection.LEFT_TO_RIGHT
 
         self.results = Results(
             atom_order=optimat.permute_tuple(

--- a/emu_mps/mps_backend_impl.py
+++ b/emu_mps/mps_backend_impl.py
@@ -101,12 +101,13 @@ class MPSBackendImpl:
     well_prepared_qubits_filter: Optional[torch.Tensor]
     hamiltonian: MPO
     state: MPS
+    left_baths: list[torch.Tensor]
     right_baths: list[torch.Tensor]
-    sweep_index: int
-    swipe_direction: SwipeDirection
-    timestep_index: int
     target_time: float
     results: Results
+    _swipe_direction: SwipeDirection
+    _sweep_index: int = 0
+    _timestep_index: int = 0
 
     def __init__(self, mps_config: MPSConfig, pulser_data: SequenceData):
         self.config = mps_config
@@ -137,11 +138,9 @@ class MPSBackendImpl:
         )
 
         self.hamiltonian_type = pulser_data.hamiltonian_type
-        self.left_baths: list[torch.Tensor]
         self.time = time.time()
-        self.swipe_direction = SwipeDirection.LEFT_TO_RIGHT
-        self.sweep_index = 0
-        self.timestep_index = 0
+        self._swipe_direction = SwipeDirection.LEFT_TO_RIGHT
+
         self.results = Results(
             atom_order=optimat.permute_tuple(
                 pulser_data.qubit_ids, self.qubit_permutation
@@ -293,18 +292,18 @@ class MPSBackendImpl:
     def update_H(self) -> None:
         update_H(
             hamiltonian=self.hamiltonian,
-            omega=self.omega[self.timestep_index, :],
-            delta=self.delta[self.timestep_index, :],
-            phi=self.phi[self.timestep_index, :],
+            omega=self.omega[self._timestep_index, :],
+            delta=self.delta[self._timestep_index, :],
+            phi=self.phi[self._timestep_index, :],
             noise=self.lindblad_noise,
         )
 
     def update_H_no_noise(self) -> None:
         update_H(
             hamiltonian=self.hamiltonian,
-            omega=self.omega[self.timestep_index, :],
-            delta=self.delta[self.timestep_index, :],
-            phi=self.phi[self.timestep_index, :],
+            omega=self.omega[self._timestep_index, :],
+            delta=self.delta[self._timestep_index, :],
+            phi=self.phi[self._timestep_index, :],
             noise=torch.zeros(self.dim, self.dim, dtype=dtype),  # no noise
         )
 
@@ -330,7 +329,7 @@ class MPSBackendImpl:
         self.init_baths()
 
     def is_finished(self) -> bool:
-        return self.timestep_index >= self.timestep_count
+        return self._timestep_index >= self.timestep_count
 
     def _evolve(
         self, *indices: int, dt: float, orth_center_right: Optional[bool] = None
@@ -383,8 +382,8 @@ class MPSBackendImpl:
         """
         Do one unit of simulation work given the current state.
         Update the state accordingly.
-        The state of the simulation is stored in self.sweep_index and
-        self.swipe_direction.
+        The state of the simulation is stored in self._sweep_index and
+        self._swipe_direction.
         """
         if self.is_finished():
             return
@@ -394,8 +393,8 @@ class MPSBackendImpl:
         assert self.qubit_count >= 1
         if 1 <= self.qubit_count <= 2:
             # Corner case: only 1 or 2 qubits
-            assert self.swipe_direction == SwipeDirection.LEFT_TO_RIGHT
-            assert self.sweep_index == 0
+            assert self._swipe_direction is SwipeDirection.LEFT_TO_RIGHT
+            assert self._sweep_index == 0
 
             if self.qubit_count == 1:
                 self._evolve(0, dt=delta_time)
@@ -403,75 +402,66 @@ class MPSBackendImpl:
                 self._evolve(0, 1, dt=delta_time, orth_center_right=False)
 
             self.sweep_complete()
+            self.save_simulation()
+            return
 
-        elif (
-            self.sweep_index < self.qubit_count - 2
-            and self.swipe_direction == SwipeDirection.LEFT_TO_RIGHT
-        ):
+        if self._swipe_direction is SwipeDirection.LEFT_TO_RIGHT:
             # Left-to-right swipe of TDVP
-            self._evolve(
-                self.sweep_index,
-                self.sweep_index + 1,
-                dt=delta_time / 2,
-                orth_center_right=True,
-            )
-            self.left_baths.append(
-                new_left_bath(
-                    self.get_current_left_bath(),
-                    self.state.factors[self.sweep_index],
-                    self.hamiltonian.factors[self.sweep_index],
-                ).to(self.state.factors[self.sweep_index + 1].device)
-            )
-            self._evolve(self.sweep_index + 1, dt=-delta_time / 2)
-            self.right_baths.pop()
-            self.sweep_index += 1
+            if self._sweep_index < self.qubit_count - 2:
+                self._evolve(
+                    self._sweep_index,
+                    self._sweep_index + 1,
+                    dt=delta_time / 2,
+                    orth_center_right=True,
+                )
+                self.left_baths.append(
+                    new_left_bath(
+                        self.get_current_left_bath(),
+                        self.state.factors[self._sweep_index],
+                        self.hamiltonian.factors[self._sweep_index],
+                    ).to(self.state.factors[self._sweep_index + 1].device)
+                )
+                self._evolve(self._sweep_index + 1, dt=-delta_time / 2)
+                self.right_baths.pop()
+                self._sweep_index += 1
 
-        elif (
-            self.sweep_index == self.qubit_count - 2
-            and self.swipe_direction == SwipeDirection.LEFT_TO_RIGHT
-        ):
-            # Time-evolution of the rightmost 2 tensors
-            self._evolve(
-                self.sweep_index,
-                self.sweep_index + 1,
-                dt=delta_time,
-                orth_center_right=False,
-            )
-            self.swipe_direction = SwipeDirection.RIGHT_TO_LEFT
+            else:
+                # Time-evolution of the rightmost 2 tensors
+                self._evolve(
+                    self._sweep_index,
+                    self._sweep_index + 1,
+                    dt=delta_time,
+                    orth_center_right=False,
+                )
+                self._swipe_direction = SwipeDirection.RIGHT_TO_LEFT
 
-        elif (
-            1 <= self.sweep_index and self.swipe_direction == SwipeDirection.RIGHT_TO_LEFT
-        ):
+        else:
             # Right-to-left swipe of TDVP
-            assert self.sweep_index <= self.qubit_count - 2
             self.right_baths.append(
                 new_right_bath(
                     self.get_current_right_bath(),
-                    self.state.factors[self.sweep_index + 1],
-                    self.hamiltonian.factors[self.sweep_index + 1],
-                ).to(self.state.factors[self.sweep_index].device)
+                    self.state.factors[self._sweep_index + 1],
+                    self.hamiltonian.factors[self._sweep_index + 1],
+                ).to(self.state.factors[self._sweep_index].device)
             )
             if not self.has_lindblad_noise:
                 # Free memory because it won't be used anymore
                 deallocate_tensor(self.right_baths[-2])
 
-            self._evolve(self.sweep_index, dt=-delta_time / 2)
+            self._evolve(self._sweep_index, dt=-delta_time / 2)
             self.left_baths.pop()
 
             self._evolve(
-                self.sweep_index - 1,
-                self.sweep_index,
+                self._sweep_index - 1,
+                self._sweep_index,
                 dt=delta_time / 2,
                 orth_center_right=False,
             )
-            self.sweep_index -= 1
+            self._sweep_index -= 1
 
-            if self.sweep_index == 0:
+            if self._sweep_index == 0:
                 self.sweep_complete()
-                self.swipe_direction = SwipeDirection.LEFT_TO_RIGHT
-
-        else:
-            raise Exception("Didn't expect this")
+                self._swipe_direction = SwipeDirection.LEFT_TO_RIGHT
 
         self.save_simulation()
 
@@ -481,7 +471,7 @@ class MPSBackendImpl:
 
     def timestep_complete(self) -> None:
         self.fill_results()
-        self.timestep_index += 1
+        self._timestep_index += 1
         interaction_matrix = self._get_interaction_matrix()  # at new time
 
         is_the_same_matrix = torch.allclose(
@@ -499,7 +489,7 @@ class MPSBackendImpl:
             )
 
         if not self.is_finished():
-            self.target_time = self.target_times[self.timestep_index + 1]
+            self.target_time = self.target_times[self._timestep_index + 1]
             self.update_H()
             self.init_baths()
 
@@ -712,7 +702,7 @@ class NoisyMPSBackendImpl(MPSBackendImpl):
 
         if self.root_finder.is_converged(tolerance=1):
             self.do_random_quantum_jump()
-            self.target_time = self.target_times[self.timestep_index + 1]
+            self.target_time = self.target_times[self._timestep_index + 1]
             self.root_finder = None
         else:
             self.target_time = self.root_finder.get_next_abscissa()
@@ -773,13 +763,13 @@ class DMRGBackendImpl(MPSBackendImpl):
             return
 
         # perform one two-site energy minimization and update
-        idx = self.sweep_index
-        assert self.swipe_direction in (
+        idx = self._sweep_index
+        assert self._swipe_direction in (
             SwipeDirection.LEFT_TO_RIGHT,
             SwipeDirection.RIGHT_TO_LEFT,
         ), "Unknown Swipe direction"
 
-        orth_center_right = self.swipe_direction == SwipeDirection.LEFT_TO_RIGHT
+        orth_center_right = self._swipe_direction == SwipeDirection.LEFT_TO_RIGHT
         new_L, new_R, energy = minimize_energy_pair(
             state_factors=self.state.factors[idx : idx + 2],
             ham_factors=self.hamiltonian.factors[idx : idx + 2],
@@ -793,9 +783,9 @@ class DMRGBackendImpl(MPSBackendImpl):
         self.current_energy = energy
 
         # updating baths and orthogonality center
-        if self.swipe_direction == SwipeDirection.LEFT_TO_RIGHT:
+        if self._swipe_direction == SwipeDirection.LEFT_TO_RIGHT:
             self._left_to_right_update(idx)
-        elif self.swipe_direction == SwipeDirection.RIGHT_TO_LEFT:
+        elif self._swipe_direction == SwipeDirection.RIGHT_TO_LEFT:
             self._right_to_left_update(idx)
         else:
             raise Exception("Did not expect this")
@@ -812,10 +802,10 @@ class DMRGBackendImpl(MPSBackendImpl):
                 ).to(self.state.factors[idx + 1].device)
             )
             self.right_baths.pop()
-            self.sweep_index += 1
+            self._sweep_index += 1
 
-        if self.sweep_index == self.qubit_count - 2:
-            self.swipe_direction = SwipeDirection.RIGHT_TO_LEFT
+        if self._sweep_index == self.qubit_count - 2:
+            self._swipe_direction = SwipeDirection.RIGHT_TO_LEFT
 
     def _right_to_left_update(self, idx: int) -> None:
         if idx > 0:
@@ -827,11 +817,11 @@ class DMRGBackendImpl(MPSBackendImpl):
                 ).to(self.state.factors[idx].device)
             )
             self.left_baths.pop()
-            self.sweep_index -= 1
+            self._sweep_index -= 1
 
-        if self.sweep_index == 0:
+        if self._sweep_index == 0:
             self.state.orthogonalize(0)
-            self.swipe_direction = SwipeDirection.LEFT_TO_RIGHT
+            self._swipe_direction = SwipeDirection.LEFT_TO_RIGHT
             self.sweep_count += 1
             self.sweep_complete()
 
@@ -847,9 +837,9 @@ class DMRGBackendImpl(MPSBackendImpl):
             # not converged for the current sweep. restart
             self.previous_energy = self.current_energy
 
-        assert self.sweep_index == 0
+        assert self._sweep_index == 0
         assert self.state.orthogonality_center == 0
-        assert self.swipe_direction == SwipeDirection.LEFT_TO_RIGHT
+        assert self._swipe_direction == SwipeDirection.LEFT_TO_RIGHT
         self.current_energy = None
 
 

--- a/emu_mps/mps_backend_impl.py
+++ b/emu_mps/mps_backend_impl.py
@@ -406,37 +406,43 @@ class MPSBackendImpl:
             return
 
         if self._swipe_direction is SwipeDirection.LEFT_TO_RIGHT:
-            # Left-to-right swipe of TDVP
-            if self._sweep_index < self.qubit_count - 2:
-                self._evolve(
-                    self._sweep_index,
-                    self._sweep_index + 1,
-                    dt=delta_time / 2,
-                    orth_center_right=True,
-                )
-                self.left_baths.append(
-                    new_left_bath(
-                        self.get_current_left_bath(),
-                        self.state.factors[self._sweep_index],
-                        self.hamiltonian.factors[self._sweep_index],
-                    ).to(self.state.factors[self._sweep_index + 1].device)
-                )
-                self._evolve(self._sweep_index + 1, dt=-delta_time / 2)
-                self.right_baths.pop()
-                self._sweep_index += 1
-
-            else:
-                # Time-evolution of the rightmost 2 tensors
-                self._evolve(
-                    self._sweep_index,
-                    self._sweep_index + 1,
-                    dt=delta_time,
-                    orth_center_right=False,
-                )
-                self._swipe_direction = SwipeDirection.RIGHT_TO_LEFT
-
+            self._left_to_right_update_tdvp(delta_time=delta_time)
         else:
-            # Right-to-left swipe of TDVP
+            self._right_to_left_update_tdvp(delta_time=delta_time)
+
+        self.save_simulation()
+
+    def _left_to_right_update_tdvp(self, delta_time: float) -> None:
+        # Left-to-right swipe of TDVP
+        if self._sweep_index < self.qubit_count - 2:
+            self._evolve(
+                self._sweep_index,
+                self._sweep_index + 1,
+                dt=delta_time / 2,
+                orth_center_right=True,
+            )
+            self.left_baths.append(
+                new_left_bath(
+                    self.get_current_left_bath(),
+                    self.state.factors[self._sweep_index],
+                    self.hamiltonian.factors[self._sweep_index],
+                ).to(self.state.factors[self._sweep_index + 1].device)
+            )
+            self._evolve(self._sweep_index + 1, dt=-delta_time / 2)
+            self.right_baths.pop()
+            self._sweep_index += 1
+        else:
+            # Time-evolution of the rightmost 2 tensors
+            self._evolve(
+                self._sweep_index,
+                self._sweep_index + 1,
+                dt=delta_time,
+                orth_center_right=False,
+            )
+            self._swipe_direction = SwipeDirection.RIGHT_TO_LEFT
+
+    def _right_to_left_update_tdvp(self, delta_time: float) -> None:
+        if self._sweep_index > 0:
             self.right_baths.append(
                 new_right_bath(
                     self.get_current_right_bath(),
@@ -447,10 +453,8 @@ class MPSBackendImpl:
             if not self.has_lindblad_noise:
                 # Free memory because it won't be used anymore
                 deallocate_tensor(self.right_baths[-2])
-
             self._evolve(self._sweep_index, dt=-delta_time / 2)
             self.left_baths.pop()
-
             self._evolve(
                 self._sweep_index - 1,
                 self._sweep_index,
@@ -459,11 +463,9 @@ class MPSBackendImpl:
             )
             self._sweep_index -= 1
 
-            if self._sweep_index == 0:
-                self.sweep_complete()
-                self._swipe_direction = SwipeDirection.LEFT_TO_RIGHT
-
-        self.save_simulation()
+        if self._sweep_index == 0:
+            self.sweep_complete()
+            self._swipe_direction = SwipeDirection.LEFT_TO_RIGHT
 
     def sweep_complete(self) -> None:
         self.current_time = self.target_time

--- a/test/emu_mps/test_end_to_end.py
+++ b/test/emu_mps/test_end_to_end.py
@@ -677,8 +677,8 @@ def test_end_to_end_spontaneous_emission() -> None:
         # the right baths administration happens properly when a quantum jump occurs.
 
         assert len(impl.right_baths) in [
-            impl.state.num_sites - impl.sweep_index,
-            impl.state.num_sites - impl.sweep_index - 1,
+            impl.state.num_sites - impl._sweep_index,
+            impl.state.num_sites - impl._sweep_index - 1,
         ]
 
         expected_right_baths = right_baths(
@@ -843,7 +843,7 @@ def test_autosave(tmp_path, monkeypatch) -> None:
             self.last_save_time = time.time() + 999
             return save_simulation_original(self)
 
-        assert self.timestep_index == 11
+        assert self._timestep_index == 11
 
         self.last_save_time = 0  # Trigger saving regardless of time
         save_simulation_original(self)

--- a/test/emu_mps/test_mps_backend_impl.py
+++ b/test/emu_mps/test_mps_backend_impl.py
@@ -505,12 +505,12 @@ def test_progress_at_random_middle_mpssite(
     mock_new_left_bath.return_value = torch.zeros(1)
 
     dmrg = create_dmrg_mock()
-    dmrg.timestep_index = 0
+    dmrg._timestep_index = 0
     dmrg.timestep_count = 2
 
     dmrg.hamiltonian = MagicMock(factors=[None] * QUBIT_COUNT)
     dmrg.state = MagicMock(factors=[None] * QUBIT_COUNT, orthogonality_center=1)
-    dmrg.sweep_index = dmrg.state.orthogonality_center
+    dmrg._sweep_index = dmrg.state.orthogonality_center
 
     # at the 2nd MPS site (orthogonality_center = 1), the left bath must be a
     # list of 1 element
@@ -527,11 +527,11 @@ def test_progress_at_random_middle_mpssite(
 
     mock_minimize.assert_called_once()
     assert dmrg.current_energy == current_energy
-    assert dmrg.sweep_index == 2
+    assert dmrg._sweep_index == 2
     assert dmrg.state.orthogonality_center == 2
     assert len(dmrg.left_baths) == 2
     assert len(dmrg.right_baths) == 2
-    assert dmrg.swipe_direction == SwipeDirection.LEFT_TO_RIGHT
+    assert dmrg._swipe_direction == SwipeDirection.LEFT_TO_RIGHT
 
 
 @patch("emu_mps.mps_backend_impl.new_left_bath")
@@ -548,11 +548,11 @@ def test_progress_at_right_mps_boundary(
     mock_new_left_bath.return_value = torch.zeros(1)
 
     dmrg = create_dmrg_mock()
-    dmrg.timestep_index = 0
+    dmrg._timestep_index = 0
     dmrg.timestep_count = 2
 
     dmrg.state = MagicMock(factors=[None] * QUBIT_COUNT, orthogonality_center=2)
-    dmrg.sweep_index = dmrg.state.orthogonality_center
+    dmrg._sweep_index = dmrg.state.orthogonality_center
 
     dmrg.hamiltonian = MagicMock(factors=[None] * QUBIT_COUNT)
     # at the 3rd MPS site (orthogonality_center = 2), the left bath must be a
@@ -570,11 +570,11 @@ def test_progress_at_right_mps_boundary(
 
     mock_minimize.assert_called_once()
     assert dmrg.current_energy == pytest.approx(0.5)
-    assert dmrg.sweep_index == 3
+    assert dmrg._sweep_index == 3
     assert dmrg.state.orthogonality_center == 3
     assert len(dmrg.left_baths) == 3
     assert len(dmrg.right_baths) == 1
-    assert dmrg.swipe_direction == SwipeDirection.RIGHT_TO_LEFT
+    assert dmrg._swipe_direction == SwipeDirection.RIGHT_TO_LEFT
 
 
 @patch("emu_mps.mps_backend_impl.new_left_bath")
@@ -593,17 +593,17 @@ def test_left_to_right_update(
 
     dmrg = create_dmrg_mock()
     dmrg.init()
-    dmrg.sweep_index = 1
-    dmrg.swipe_direction = SwipeDirection.LEFT_TO_RIGHT
+    dmrg._sweep_index = 1
+    dmrg._swipe_direction = SwipeDirection.LEFT_TO_RIGHT
     dmrg.left_baths = [torch.zeros(1)]
     dmrg.right_baths = [torch.zeros(1)] * 3
 
     dmrg._left_to_right_update(idx=1)
 
-    assert dmrg.sweep_index == 2
+    assert dmrg._sweep_index == 2
     assert len(dmrg.left_baths) == 2
     assert len(dmrg.right_baths) == 2
-    dmrg.swipe_direction = SwipeDirection.LEFT_TO_RIGHT
+    dmrg._swipe_direction = SwipeDirection.LEFT_TO_RIGHT
 
 
 @patch("emu_mps.mps_backend_impl.new_left_bath")
@@ -630,8 +630,8 @@ def test_right_to_left_update(
 
     dmrg = create_dmrg_mock()
     dmrg.init()
-    dmrg.sweep_index = 2
-    dmrg.swipe_direction = SwipeDirection.RIGHT_TO_LEFT
+    dmrg._sweep_index = 2
+    dmrg._swipe_direction = SwipeDirection.RIGHT_TO_LEFT
     dmrg.left_baths = [
         torch.zeros(1, 1, 1, dtype=dtype, device=dmrg.state.factors[0].device)
     ] * 2
@@ -643,5 +643,5 @@ def test_right_to_left_update(
 
     assert len(dmrg.left_baths) == 1
     assert len(dmrg.right_baths) == 2
-    assert dmrg.sweep_index == 1
-    assert dmrg.swipe_direction == SwipeDirection.RIGHT_TO_LEFT
+    assert dmrg._sweep_index == 1
+    assert dmrg._swipe_direction == SwipeDirection.RIGHT_TO_LEFT


### PR DESCRIPTION
I've simplified logic in TDVP, making a first step toward generalisation.

- `_swipe_direction`, `_sweep_index` and `_timestep_index` renamed because they are internal variables of the class
- `_swipe_direction`, `_sweep_index` and `_timestep_index` have default values and its reflected in a default constructor
- Sweep direction and MPS node indexing are logically not coupled, its now reflected in the code