### PR TITLE
docs(mkdocs): fix doubled 'with' in DMRG notebook nav title

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -24,7 +24,7 @@ nav:
     - Notebooks:
       - Index: emu_mps/notebooks/index.md
       - Getting started: emu_mps/notebooks/getting_started.ipynb
-      - Getting with started with dmrg: emu_mps/notebooks/dmrg_usecase.ipynb
+      - Getting started with DMRG: emu_mps/notebooks/dmrg_usecase.ipynb
       - Noise Monte Carlo averaging: emu_mps/notebooks/noise_MonteCarlo_average_results.ipynb
       - Creating Custom Observables: emu_mps/notebooks/creating_observables_tutorial.ipynb
     - Advanced Topics:


### PR DESCRIPTION
Closes #232. The emu-mps notebooks nav entry in `mkdocs.yml` reads `Getting with started with dmrg`, which is what renders as the page title on pasqal-io.github.io/emulators/.../dmrg_usecase/. Drop the extra `with` and capitalise DMRG to match the notebook heading style.