### PR TITLE
fix notebook typo

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -24,7 +24,7 @@ nav:
     - Notebooks:
       - Index: emu_mps/notebooks/index.md
       - Getting started: emu_mps/notebooks/getting_started.ipynb
-      - Getting with started with dmrg: emu_mps/notebooks/dmrg_usecase.ipynb
+      - Getting started with DMRG: emu_mps/notebooks/dmrg_usecase.ipynb
       - Noise Monte Carlo averaging: emu_mps/notebooks/noise_MonteCarlo_average_results.ipynb
       - Creating Custom Observables: emu_mps/notebooks/creating_observables_tutorial.ipynb
     - Advanced Topics:


### PR DESCRIPTION
Fix typo in our emu_mps documentation