### PR TITLE
added dmm noise types

### DIFF
--- a/emu_base/pulser_adapter.py
+++ b/emu_base/pulser_adapter.py
@@ -19,7 +19,15 @@ class HamiltonianType(Enum):
     XY = 2
 
 
-_NON_LINDBLADIAN_NOISE = {"SPAM", "doppler", "amplitude", "detuning", "register"}
+_NON_LINDBLADIAN_NOISE = {
+    "SPAM",
+    "doppler",
+    "amplitude",
+    "detuning",
+    "register",
+    "dmm_sigma",
+    "dmm_crosstalk",
+}
 
 
 def _get_all_lindblad_noise_operators(

--- a/test/emu_base/test_adapter.py
+++ b/test/emu_base/test_adapter.py
@@ -1009,6 +1009,8 @@ def test_non_lindbladian_noise(prefer_device_model):
         trap_waist=1.0,
         state_prep_error=0.5,
         runs=1,
+        dmm_sigma=0.01,
+        detuning_map_spot_waist=0.01,
     )
     config = EmulationConfig(
         interaction_cutoff=0.0,


### PR DESCRIPTION
The new dmm noise types added in the noise model need to be added in emu-base so that it doesn't think they're lindblad noises. Required to make the following code work

To see what this supports look at the modified test.