### PR TITLE
change torch lower version

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -33,7 +33,7 @@ repos:
     hooks:
       - id: mypy
         exclude: examples|test|ci
-        additional_dependencies: ["pulser-core[torch]>=1.8.0", "torch==2.9.0,<2.11.0"]  # The version in pyproject.toml must match
+        additional_dependencies: ["pulser-core[torch]>=1.8.0", "torch~=2.7,<2.11.0"]  # The version in pyproject.toml must match
 
   - repo: https://github.com/pasqal-io/doc_checker
     rev: 53bb9d79b85d2bdc8ec7ffbc05b97749c3593583 # full SHA for the commit to use

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -39,5 +39,5 @@ abstract: >-
 keywords:
   - analog quantum computing
   - emulation
-version: 2.7.4
+version: 2.7.5
 date-released: '2025-05-12'

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -40,4 +40,4 @@ keywords:
   - analog quantum computing
   - emulation
 version: 2.7.5
-date-released: '2025-05-12'
+date-released: '2026-05-11'

--- a/ci/emu_base/pyproject.toml
+++ b/ci/emu_base/pyproject.toml
@@ -22,7 +22,7 @@ classifiers=[
     "Programming Language :: Python :: Implementation :: PyPy",
 ]
 dependencies = [
-  "pulser-core[torch]>=1.8.0", "torch>=2.9.0,<2.11.0"]
+  "pulser-core[torch]>=1.8.0", "torch~=2.7"]
 dynamic = ["version"]
 
 [project.urls]

--- a/ci/emu_mps/pyproject.toml
+++ b/ci/emu_mps/pyproject.toml
@@ -23,7 +23,7 @@ classifiers=[
 ]
 dynamic = ["version"]
 dependencies = [
-  "emu-base==2.7.4"]
+  "emu-base==2.7.5"]
 
 [project.urls]
 Documentation = "https://pasqal-io.github.io/emulators/"

--- a/ci/emu_sv/pyproject.toml
+++ b/ci/emu_sv/pyproject.toml
@@ -23,7 +23,7 @@ classifiers=[
 ]
 dynamic = ["version"]
 dependencies = [
-  "emu-base==2.7.4"]
+  "emu-base==2.7.5"]
 
 [project.urls]
 Documentation = "https://pasqal-io.github.io/emulators/"

--- a/emu_base/__init__.py
+++ b/emu_base/__init__.py
@@ -23,4 +23,4 @@ __all__ = [
     "init_logging",
 ]
 
-__version__ = "2.7.4"
+__version__ = "2.7.5"

--- a/emu_mps/__init__.py
+++ b/emu_mps/__init__.py
@@ -35,4 +35,4 @@ __all__ = [
     "EntanglementEntropy",
 ]
 
-__version__ = "2.7.4"
+__version__ = "2.7.5"

--- a/emu_sv/__init__.py
+++ b/emu_sv/__init__.py
@@ -39,4 +39,4 @@ __all__ = [
     "SparseOperator",
 ]
 
-__version__ = "2.7.4"
+__version__ = "2.7.5"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,7 +22,7 @@ classifiers=[
     "Programming Language :: Python :: Implementation :: PyPy",
 ]
 dependencies = [
-  "pulser-core[torch]>=1.8.0", "torch>=2.9.0,<2.11.0"]  # The version in .pre-commit-config.yaml must match
+  "pulser-core[torch]>=1.8.0", "torch~=2.7,<2.11.0"]  # The version in .pre-commit-config.yaml must match
 dynamic = ["version"]
 
 [tool.setuptools]

--- a/test_dependency_versions.py
+++ b/test_dependency_versions.py
@@ -24,7 +24,7 @@ def extract_version_from_oml_file(filepath: Path, pattern: str) -> Optional[str]
         for line in f:
             match = re.search(
                 pattern
-                + r'\s*>?=*\s*"?([0-9]+(?:\.[^\s"\.\,]+){2}(,<[0-9]+(?:\.[^\s"\.\,]+){2})?)"?',
+                + r'\s*[>~]?=*\s*"?([0-9]+(?:\.[^\s"\.\,]+){1,2}(,<[0-9]+(?:\.[^\s"\.\,]+){2})?)"?',
                 line,
             )
             if match:
@@ -139,9 +139,9 @@ torch_emu_base_version = extract_version_from_oml_file(
 )
 print(f" - emu-base uses torch version {torch_pyproject_version}")
 
-if torch_emu_base_version != torch_pyproject_version:
+if torch_emu_base_version not in torch_pyproject_version:
     fail(
-        f" - torch in emu-base version {torch_pre_commit_version}"
+        f" - torch in emu-base version {torch_emu_base_version}"
         f" != torch in pyproject.toml {torch_pyproject_version}"
     )
 


### PR DESCRIPTION
The ops team couldn't get torch >2.7 to work on one of the machines that we really have to support. I lowered the upper bound of torch to include 2.7. Initially I wanted to use the same bound as in pulser core (2.6) but some of the tests started failing.

I also removed the upper bound for the released packages, since there were some complaints. I kept the bound for installing from source, since it's needed for the benchmarks.