### PR TITLE
Clean up old right baths before computing new ones

### DIFF
--- a/CITATION.cff
+++ b/CITATION.cff
@@ -39,5 +39,5 @@ abstract: >-
 keywords:
   - analog quantum computing
   - emulation
-version: 2.7.5
+version: 2.7.6
 date-released: '2026-05-11'

--- a/ci/emu_mps/pyproject.toml
+++ b/ci/emu_mps/pyproject.toml
@@ -23,7 +23,7 @@ classifiers=[
 ]
 dynamic = ["version"]
 dependencies = [
-  "emu-base==2.7.5"]
+  "emu-base==2.7.6"]
 
 [project.urls]
 Documentation = "https://pasqal-io.github.io/emulators/"

--- a/ci/emu_sv/pyproject.toml
+++ b/ci/emu_sv/pyproject.toml
@@ -23,7 +23,7 @@ classifiers=[
 ]
 dynamic = ["version"]
 dependencies = [
-  "emu-base==2.7.5"]
+  "emu-base==2.7.6"]
 
 [project.urls]
 Documentation = "https://pasqal-io.github.io/emulators/"

--- a/emu_base/__init__.py
+++ b/emu_base/__init__.py
@@ -23,4 +23,4 @@ __all__ = [
     "init_logging",
 ]
 
-__version__ = "2.7.5"
+__version__ = "2.7.6"

--- a/emu_mps/__init__.py
+++ b/emu_mps/__init__.py
@@ -35,4 +35,4 @@ __all__ = [
     "EntanglementEntropy",
 ]
 
-__version__ = "2.7.5"
+__version__ = "2.7.6"

--- a/emu_mps/mps_backend_impl.py
+++ b/emu_mps/mps_backend_impl.py
@@ -308,6 +308,8 @@ class MPSBackendImpl:
         self.left_baths = [
             torch.ones(1, 1, 1, dtype=dtype, device=self.state.factors[0].device)
         ]
+        # clean up the memory in right baths, since otherwise we temporarily have
+        # both the old and the new in memory, which can cause OOM errors
         self.right_baths: list[torch.Tensor] = []
         self.right_baths = right_baths(self.state, self.hamiltonian, final_qubit=2)
         assert len(self.right_baths) == self.qubit_count - 1

--- a/emu_mps/mps_backend_impl.py
+++ b/emu_mps/mps_backend_impl.py
@@ -308,6 +308,7 @@ class MPSBackendImpl:
         self.left_baths = [
             torch.ones(1, 1, 1, dtype=dtype, device=self.state.factors[0].device)
         ]
+        self.right_baths: list[torch.Tensor] = []
         self.right_baths = right_baths(self.state, self.hamiltonian, final_qubit=2)
         assert len(self.right_baths) == self.qubit_count - 1
 

--- a/emu_sv/__init__.py
+++ b/emu_sv/__init__.py
@@ -39,4 +39,4 @@ __all__ = [
     "SparseOperator",
 ]
 
-__version__ = "2.7.5"
+__version__ = "2.7.6"


### PR DESCRIPTION
When starting a new TDVP sweep, emu-mps was temprarily keeping both the old and the new right baths in memory. Usually, this is not a problem since the Lanczos algorithm is the most memory-intensive part of the program, but for larger qubit numbers, there are situations where this causes the program to OOM when creating the new baths.

This MR fixes the issue.