### PR TITLE
Reorder single qubit driving terms in emu-mps

### DIFF
--- a/CITATION.cff
+++ b/CITATION.cff
@@ -39,5 +39,5 @@ abstract: >-
 keywords:
   - analog quantum computing
   - emulation
-version: 2.7.6
+version: 2.7.7
 date-released: '2026-05-11'

--- a/ci/emu_mps/pyproject.toml
+++ b/ci/emu_mps/pyproject.toml
@@ -23,7 +23,7 @@ classifiers=[
 ]
 dynamic = ["version"]
 dependencies = [
-  "emu-base==2.7.6"]
+  "emu-base==2.7.7"]
 
 [project.urls]
 Documentation = "https://pasqal-io.github.io/emulators/"

--- a/ci/emu_sv/pyproject.toml
+++ b/ci/emu_sv/pyproject.toml
@@ -23,7 +23,7 @@ classifiers=[
 ]
 dynamic = ["version"]
 dependencies = [
-  "emu-base==2.7.6"]
+  "emu-base==2.7.7"]
 
 [project.urls]
 Documentation = "https://pasqal-io.github.io/emulators/"

--- a/emu_base/__init__.py
+++ b/emu_base/__init__.py
@@ -23,4 +23,4 @@ __all__ = [
     "init_logging",
 ]
 
-__version__ = "2.7.6"
+__version__ = "2.7.7"

--- a/emu_base/pulser_adapter.py
+++ b/emu_base/pulser_adapter.py
@@ -123,12 +123,14 @@ def _extract_omega_delta_phi(
         raise ValueError(
             "Only `ground-rydberg` and `mw_global`(XY) channels are supported."
         )
-    qubit_ids_filtered = [qid for qid in qubit_ids if qid in locals_a_d_p]
+    qubit_ids_filtered = [
+        (qpos, qid) for qpos, qid in enumerate(qubit_ids) if qid in locals_a_d_p
+    ]
 
     target_t = torch.as_tensor(target_times, dtype=torch.float64)
     t_mid = 0.5 * (target_t[:-1] + target_t[1:])
 
-    shape = (t_mid.numel(), len(qubit_ids_filtered))
+    shape = (t_mid.numel(), len(qubit_ids))
     omega_mid = torch.zeros(shape, dtype=torch.float64, device=t_mid.device)
     delta_mid = torch.zeros(shape, dtype=torch.float64, device=t_mid.device)
     phi_mid = torch.zeros(shape, dtype=torch.float64, device=t_mid.device)
@@ -142,7 +144,7 @@ def _extract_omega_delta_phi(
         "phase": phi_mid,
     }
     for name, data_mid in laser_by_data.items():
-        for q_pos, q_id in enumerate(qubit_ids_filtered):
+        for q_pos, q_id in qubit_ids_filtered:
             signal = torch.as_tensor(locals_a_d_p[q_id][name])
             if torch.is_complex(signal) and not torch.allclose(
                 signal.imag, torch.zeros_like(signal.imag)

--- a/emu_mps/__init__.py
+++ b/emu_mps/__init__.py
@@ -35,4 +35,4 @@ __all__ = [
     "EntanglementEntropy",
 ]
 
-__version__ = "2.7.6"
+__version__ = "2.7.7"

--- a/emu_mps/mps_backend_impl.py
+++ b/emu_mps/mps_backend_impl.py
@@ -120,10 +120,6 @@ class MPSBackendImpl:
             "Consider using the emu_sv backend."
         )
 
-        self.omega = pulser_data.omega
-        self.delta = pulser_data.delta
-        self.phi = pulser_data.phi
-        self.timestep_count: int = self.omega.shape[0]
         self.has_lindblad_noise = len(pulser_data.lindblad_ops) > 0
         self.eigenstates = pulser_data.eigenstates
         self.dim = pulser_data.dim
@@ -136,6 +132,11 @@ class MPSBackendImpl:
             if self.config.optimize_qubit_ordering
             else optimat.eye_permutation(self.qubit_count)
         )
+
+        self.omega = pulser_data.omega[:, self.qubit_permutation]
+        self.delta = pulser_data.delta[:, self.qubit_permutation]
+        self.phi = pulser_data.phi[:, self.qubit_permutation]
+        self.timestep_count: int = self.omega.shape[0]
 
         self.hamiltonian_type = pulser_data.hamiltonian_type
         self.time = time.time()

--- a/emu_sv/__init__.py
+++ b/emu_sv/__init__.py
@@ -39,4 +39,4 @@ __all__ = [
     "SparseOperator",
 ]
 
-__version__ = "2.7.6"
+__version__ = "2.7.7"

--- a/test/emu_base/test_adapter.py
+++ b/test/emu_base/test_adapter.py
@@ -1057,11 +1057,16 @@ def test_extract_omega_delta_phi_missing_qubit():
         qubit_ids=qubit_ids,
         target_times=target_times,
     )
-    omega_expected = {
-        0: torch.tensor([1.5, 2.5, 3.5, 4.5, 5.5, 6.5], dtype=dtype),  # q0
-        1: torch.zeros(pulse_duration, dtype=dtype),
-        2: torch.tensor([5.5, 4.5, 3.5, 2.5, 1.5, 0.5], dtype=dtype),  # q2
-    }
+    omega_expected = torch.tensor(
+        [
+            [1.5, 0.0, 5.5],
+            [2.5, 0.0, 4.5],
+            [3.5, 0.0, 3.5],
+            [4.5, 0.0, 2.5],
+            [5.5, 0.0, 1.5],
+            [6.5, 0.0, 0.5],
+        ],
+        dtype=dtype,
+    )
 
-    for col, expected in omega_expected.items():
-        assert torch.allclose(omega[:, col], expected)
+    assert torch.allclose(omega, omega_expected)

--- a/test/emu_base/test_adapter.py
+++ b/test/emu_base/test_adapter.py
@@ -1025,8 +1025,7 @@ def test_non_lindbladian_noise(prefer_device_model):
 
 def test_extract_omega_delta_phi_missing_qubit():
     """
-    Test that qubits not present in the pulse samples are filtered out
-    Only qubits included in the pulser sequence are used to fill omega, delta, and phi.
+    Test that qubits not present in the pulse samples have zero omega, delta, and phi.
     """
     pulse_duration = 6
     target_times = list(range(pulse_duration + 1))
@@ -1060,7 +1059,8 @@ def test_extract_omega_delta_phi_missing_qubit():
     )
     omega_expected = {
         0: torch.tensor([1.5, 2.5, 3.5, 4.5, 5.5, 6.5], dtype=dtype),  # q0
-        1: torch.tensor([5.5, 4.5, 3.5, 2.5, 1.5, 0.5], dtype=dtype),  # q2
+        1: torch.zeros(pulse_duration, dtype=dtype),
+        2: torch.tensor([5.5, 4.5, 3.5, 2.5, 1.5, 0.5], dtype=dtype),  # q2
     }
 
     for col, expected in omega_expected.items():

--- a/test/emu_mps/test_end_to_end.py
+++ b/test/emu_mps/test_end_to_end.py
@@ -1269,7 +1269,7 @@ def test_qubit_reordering_no_interaction():
     reg = pulser.Register.rectangle(4, 4, spacing=1e10, prefix="q")
     seq = pulser.Sequence(reg, pulser.MockDevice)
     seq.declare_channel("ising", "rydberg_local")
-    seq.target("q4", "ising")
+    seq.target(["q4", "q5"], "ising")
     duration = 1000
     seq.add(
         pulser.Pulse.ConstantAmplitude(
@@ -1284,10 +1284,11 @@ def test_qubit_reordering_no_interaction():
     backend = MPSBackend(seq, config=config)
     with patch("emu_mps.mps_backend_impl.optimat.minimize_bandwidth") as reordering_mock:
         reordering_mock.return_value = torch.tensor(
-            [0, 4, 1, 2, 3, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15]
+            [0, 1, 4, 5, 2, 3, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15]
         )
         results = backend.run()
     occ = np.array(results.occupation[-1])
     expected_occ = np.zeros_like(occ)
     expected_occ[4] = 1
+    expected_occ[5] = 1
     np.testing.assert_allclose(occ, expected_occ)

--- a/test/emu_mps/test_end_to_end.py
+++ b/test/emu_mps/test_end_to_end.py
@@ -1263,3 +1263,31 @@ def test_run_from_sequence_data():
     assert results.get_result_times("occupation") == occup.evaluation_times.tolist()
     assert results.occupation[0] == pytest.approx(0.0)
     assert results.occupation[-1] == pytest.approx(1.0)
+
+
+def test_qubit_reordering_no_interaction():
+    reg = pulser.Register.rectangle(4, 4, spacing=1e10, prefix="q")
+    seq = pulser.Sequence(reg, pulser.MockDevice)
+    seq.declare_channel("ising", "rydberg_local")
+    seq.target("q4", "ising")
+    duration = 1000
+    seq.add(
+        pulser.Pulse.ConstantAmplitude(
+            amplitude=torch.pi,
+            detuning=pulser.waveforms.ConstantWaveform(duration=duration, value=0.0),
+            phase=0.0,
+        ),
+        "ising",
+    )
+
+    config = MPSConfig(observables=[Occupation()], dt=100)
+    backend = MPSBackend(seq, config=config)
+    with patch("emu_mps.mps_backend_impl.optimat.minimize_bandwidth") as reordering_mock:
+        reordering_mock.return_value = torch.tensor(
+            [0, 4, 1, 2, 3, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15]
+        )
+        results = backend.run()
+    occ = np.array(results.occupation[-1])
+    expected_occ = np.zeros_like(occ)
+    expected_occ[4] = 1
+    np.testing.assert_allclose(occ, expected_occ)


### PR DESCRIPTION
When `MPSConfig.optimize_qubit_ordering == True`, the single qubit driving terms in the Hamiltonian need to be reordered along with the interaction matrix, the initial state etc. In `MPSBackendImpl` this is now done.

Independently, there was an issue in `PulserAdapter` where qubits were missing in the `omega`, `delta` and `phi` tensors. This caused the driving terms to added to the incorrect qubit in the Hamiltonian regardless of qubit reordering. I also fixed this issue, and there are tests.