### PR TITLE
cast numpy.bool to bool in emu-base

### DIFF
--- a/CITATION.cff
+++ b/CITATION.cff
@@ -40,4 +40,4 @@ keywords:
   - analog quantum computing
   - emulation
 version: 2.7.8
-date-released: '2026-05-11'
+date-released: '2026-06-18'

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -39,5 +39,5 @@ abstract: >-
 keywords:
   - analog quantum computing
   - emulation
-version: 2.7.7
+version: 2.7.8
 date-released: '2026-05-11'

--- a/ci/emu_mps/pyproject.toml
+++ b/ci/emu_mps/pyproject.toml
@@ -23,7 +23,7 @@ classifiers=[
 ]
 dynamic = ["version"]
 dependencies = [
-  "emu-base==2.7.7"]
+  "emu-base==2.7.8"]
 
 [project.urls]
 Documentation = "https://pasqal-io.github.io/emulators/"

--- a/ci/emu_sv/pyproject.toml
+++ b/ci/emu_sv/pyproject.toml
@@ -23,7 +23,7 @@ classifiers=[
 ]
 dynamic = ["version"]
 dependencies = [
-  "emu-base==2.7.7"]
+  "emu-base==2.7.8"]
 
 [project.urls]
 Documentation = "https://pasqal-io.github.io/emulators/"

--- a/emu_base/__init__.py
+++ b/emu_base/__init__.py
@@ -23,4 +23,4 @@ __all__ = [
     "init_logging",
 ]
 
-__version__ = "2.7.7"
+__version__ = "2.7.8"

--- a/emu_base/pulser_adapter.py
+++ b/emu_base/pulser_adapter.py
@@ -317,10 +317,7 @@ class PulserData:
                     phi,
                     interaction_matrix,
                     tuple(samples.trajectory.bad_atoms.keys()),
-                    tuple(
-                        True if x else False
-                        for x in samples.trajectory.bad_atoms.values()
-                    ),
+                    tuple(bool(x) for x in samples.trajectory.bad_atoms.values()),
                     self.lindblad_ops,
                     self.noise_model.state_prep_error,
                     self.target_times,

--- a/emu_base/pulser_adapter.py
+++ b/emu_base/pulser_adapter.py
@@ -317,7 +317,10 @@ class PulserData:
                     phi,
                     interaction_matrix,
                     tuple(samples.trajectory.bad_atoms.keys()),
-                    tuple(samples.trajectory.bad_atoms.values()),
+                    tuple(
+                        True if x else False
+                        for x in samples.trajectory.bad_atoms.values()
+                    ),
                     self.lindblad_ops,
                     self.noise_model.state_prep_error,
                     self.target_times,

--- a/emu_mps/__init__.py
+++ b/emu_mps/__init__.py
@@ -35,4 +35,4 @@ __all__ = [
     "EntanglementEntropy",
 ]
 
-__version__ = "2.7.7"
+__version__ = "2.7.8"

--- a/emu_sv/__init__.py
+++ b/emu_sv/__init__.py
@@ -39,4 +39,4 @@ __all__ = [
     "SparseOperator",
 ]
 
-__version__ = "2.7.7"
+__version__ = "2.7.8"


### PR DESCRIPTION
older versions of torch dont handle `numpy.bool` correctly. Bad atoms are currently specified as a `numpy.bool`. In this MR, I cast them to normal `bool` in `PulserAdapter` so we don't have to worry about the types in the emulators.